### PR TITLE
feat: add analytics and usage tracking

### DIFF
--- a/src/atdata_app/database.py
+++ b/src/atdata_app/database.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from importlib import resources
@@ -549,6 +550,199 @@ async def query_record_counts(pool: asyncpg.Pool) -> dict[str, int]:
             row = await conn.fetchrow(f"SELECT COUNT(*) as cnt FROM {table}")  # noqa: S608
             counts[collection] = row["cnt"]
         return counts
+
+
+# ---------------------------------------------------------------------------
+# Analytics
+# ---------------------------------------------------------------------------
+
+
+async def record_analytics_event(
+    pool: asyncpg.Pool,
+    event_type: str,
+    target_did: str | None = None,
+    target_rkey: str | None = None,
+    query_params: dict[str, Any] | None = None,
+) -> None:
+    """Insert an analytics event. Designed to be called via asyncio.create_task()."""
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO analytics_events (event_type, target_did, target_rkey, query_params)
+                VALUES ($1, $2, $3, $4::jsonb)
+                """,
+                event_type,
+                target_did,
+                target_rkey,
+                json.dumps(query_params) if query_params else None,
+            )
+            # Bump the pre-aggregated counter if we have a target
+            if target_did and target_rkey:
+                await conn.execute(
+                    """
+                    INSERT INTO analytics_counters (target_did, target_rkey, event_type, count, last_updated)
+                    VALUES ($1, $2, $3, 1, NOW())
+                    ON CONFLICT (target_did, target_rkey, event_type) DO UPDATE SET
+                        count = analytics_counters.count + 1,
+                        last_updated = NOW()
+                    """,
+                    target_did,
+                    target_rkey,
+                    event_type,
+                )
+    except Exception:
+        logger.warning("Failed to record analytics event %s", event_type, exc_info=True)
+
+
+def fire_analytics_event(
+    pool: asyncpg.Pool,
+    event_type: str,
+    target_did: str | None = None,
+    target_rkey: str | None = None,
+    query_params: dict[str, Any] | None = None,
+) -> None:
+    """Fire-and-forget analytics recording. Does not block the caller."""
+    asyncio.create_task(
+        record_analytics_event(pool, event_type, target_did, target_rkey, query_params)
+    )
+
+
+PERIOD_INTERVALS = {
+    "day": "1 day",
+    "week": "7 days",
+    "month": "30 days",
+}
+
+
+async def query_analytics_summary(
+    pool: asyncpg.Pool,
+    period: str = "week",
+) -> dict[str, Any]:
+    """Aggregate analytics for the getAnalytics endpoint."""
+    interval = PERIOD_INTERVALS.get(period, "7 days")
+    async with pool.acquire() as conn:
+        # Total views (view_entry + view_schema events)
+        row = await conn.fetchrow(
+            """
+            SELECT
+                COUNT(*) FILTER (WHERE event_type LIKE 'view_%') AS total_views,
+                COUNT(*) FILTER (WHERE event_type = 'search') AS total_searches
+            FROM analytics_events
+            WHERE created_at >= NOW() - $1::interval
+            """,
+            interval,
+        )
+        total_views = row["total_views"]
+        total_searches = row["total_searches"]
+
+        # Top datasets by view count in period
+        top_rows = await conn.fetch(
+            """
+            SELECT e.target_did, e.target_rkey, ent.name, COUNT(*) AS views
+            FROM analytics_events e
+            LEFT JOIN entries ent ON ent.did = e.target_did AND ent.rkey = e.target_rkey
+            WHERE e.event_type = 'view_entry'
+              AND e.created_at >= NOW() - $1::interval
+              AND e.target_did IS NOT NULL
+            GROUP BY e.target_did, e.target_rkey, ent.name
+            ORDER BY views DESC
+            LIMIT 10
+            """,
+            interval,
+        )
+        top_datasets = [
+            {
+                "uri": f"at://{r['target_did']}/ac.foundation.dataset.record/{r['target_rkey']}",
+                "did": r["target_did"],
+                "rkey": r["target_rkey"],
+                "name": r["name"] or "",
+                "views": r["views"],
+            }
+            for r in top_rows
+        ]
+
+        # Top search terms
+        term_rows = await conn.fetch(
+            """
+            SELECT query_params->>'q' AS term, COUNT(*) AS count
+            FROM analytics_events
+            WHERE event_type = 'search'
+              AND query_params->>'q' IS NOT NULL
+              AND created_at >= NOW() - $1::interval
+            GROUP BY term
+            ORDER BY count DESC
+            LIMIT 10
+            """,
+            interval,
+        )
+        top_search_terms = [
+            {"term": r["term"], "count": r["count"]} for r in term_rows
+        ]
+
+        # Record counts
+        counts = {}
+        for collection, table in COLLECTION_TABLE_MAP.items():
+            c = await conn.fetchrow(f"SELECT COUNT(*) AS cnt FROM {table}")  # noqa: S608
+            counts[collection] = c["cnt"]
+
+        return {
+            "totalViews": total_views,
+            "totalSearches": total_searches,
+            "topDatasets": top_datasets,
+            "topSearchTerms": top_search_terms,
+            "recordCounts": counts,
+        }
+
+
+async def query_entry_stats(
+    pool: asyncpg.Pool,
+    did: str,
+    rkey: str,
+    period: str = "week",
+) -> dict[str, Any]:
+    """Get analytics stats for a specific dataset entry."""
+    interval = PERIOD_INTERVALS.get(period, "7 days")
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT
+                COUNT(*) FILTER (WHERE event_type = 'view_entry') AS views,
+                COUNT(*) FILTER (WHERE event_type = 'search') AS search_appearances
+            FROM analytics_events
+            WHERE target_did = $1 AND target_rkey = $2
+              AND created_at >= NOW() - $3::interval
+            """,
+            did,
+            rkey,
+            interval,
+        )
+        return {
+            "views": row["views"],
+            "searchAppearances": row["search_appearances"],
+            "period": period,
+        }
+
+
+async def query_active_publishers(pool: asyncpg.Pool, days: int = 30) -> int:
+    """Count distinct publishers with records indexed in the last N days."""
+    interval = f"{days} days"
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT COUNT(DISTINCT did) AS cnt FROM (
+                SELECT did FROM entries WHERE indexed_at >= NOW() - $1::interval
+                UNION
+                SELECT did FROM schemas WHERE indexed_at >= NOW() - $1::interval
+                UNION
+                SELECT did FROM labels WHERE indexed_at >= NOW() - $1::interval
+                UNION
+                SELECT did FROM lenses WHERE indexed_at >= NOW() - $1::interval
+            ) sub
+            """,
+            interval,
+        )
+        return row["cnt"]
 
 
 async def query_record_exists(

--- a/src/atdata_app/models.py
+++ b/src/atdata_app/models.py
@@ -207,3 +207,18 @@ class DescribeServiceResponse(BaseModel):
     did: str
     availableCollections: list[str]
     recordCount: dict[str, int]
+    analytics: dict[str, Any] | None = None
+
+
+class GetAnalyticsResponse(BaseModel):
+    totalViews: int
+    totalSearches: int
+    topDatasets: list[dict[str, Any]]
+    topSearchTerms: list[dict[str, Any]]
+    recordCounts: dict[str, int]
+
+
+class GetEntryStatsResponse(BaseModel):
+    views: int
+    searchAppearances: int
+    period: str

--- a/src/atdata_app/sql/schema.sql
+++ b/src/atdata_app/sql/schema.sql
@@ -112,3 +112,28 @@ CREATE TABLE IF NOT EXISTS cursor_state (
     cursor      BIGINT NOT NULL,
     updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
+
+-- Analytics events (lightweight server-side request counting)
+CREATE TABLE IF NOT EXISTS analytics_events (
+    id           BIGSERIAL PRIMARY KEY,
+    event_type   TEXT NOT NULL,
+    target_did   TEXT,
+    target_rkey  TEXT,
+    query_params JSONB,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_analytics_events_type_created
+    ON analytics_events (event_type, created_at);
+CREATE INDEX IF NOT EXISTS idx_analytics_events_target
+    ON analytics_events (target_did, target_rkey, event_type);
+
+-- Pre-aggregated analytics counters (avoids expensive COUNT on events table)
+CREATE TABLE IF NOT EXISTS analytics_counters (
+    target_did   TEXT NOT NULL,
+    target_rkey  TEXT NOT NULL,
+    event_type   TEXT NOT NULL,
+    count        BIGINT NOT NULL DEFAULT 0,
+    last_updated TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (target_did, target_rkey, event_type)
+);

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,0 +1,376 @@
+"""Tests for analytics and usage tracking."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from atdata_app.config import AppConfig
+from atdata_app.database import (
+    fire_analytics_event,
+    record_analytics_event,
+)
+from atdata_app.main import create_app
+from atdata_app.models import (
+    DescribeServiceResponse,
+    GetAnalyticsResponse,
+    GetEntryStatsResponse,
+)
+
+_DB = "atdata_app.xrpc.queries"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def config() -> AppConfig:
+    return AppConfig(dev_mode=True, hostname="localhost", port=8000)
+
+
+@pytest.fixture
+def pool() -> AsyncMock:
+    return AsyncMock()
+
+
+def _mock_app(config: AppConfig, pool: AsyncMock):
+    """Create a FastAPI app with mocked lifespan (no real DB)."""
+    app = create_app(config)
+    app.state.db_pool = pool
+    return app
+
+
+# ---------------------------------------------------------------------------
+# record_analytics_event
+# ---------------------------------------------------------------------------
+
+
+def _pool_with_conn():
+    """Create a mock pool whose acquire() returns an async context manager with a mock conn."""
+    mock_conn = AsyncMock()
+    mock_pool = MagicMock()
+    ctx = AsyncMock()
+    ctx.__aenter__ = AsyncMock(return_value=mock_conn)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    mock_pool.acquire.return_value = ctx
+    return mock_pool, mock_conn
+
+
+@pytest.mark.asyncio
+async def test_record_analytics_event_inserts_event():
+    mock_pool, mock_conn = _pool_with_conn()
+
+    await record_analytics_event(mock_pool, "view_entry", target_did="did:plc:abc", target_rkey="3xyz")
+
+    # Should have called execute twice: once for the event INSERT, once for the counter upsert
+    assert mock_conn.execute.call_count == 2
+    first_call = mock_conn.execute.call_args_list[0]
+    assert "INSERT INTO analytics_events" in first_call[0][0]
+    assert first_call[0][1] == "view_entry"
+    assert first_call[0][2] == "did:plc:abc"
+    assert first_call[0][3] == "3xyz"
+
+
+@pytest.mark.asyncio
+async def test_record_analytics_event_no_counter_without_target():
+    mock_pool, mock_conn = _pool_with_conn()
+
+    await record_analytics_event(mock_pool, "describe")
+
+    # Only the event INSERT, no counter upsert
+    assert mock_conn.execute.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_record_analytics_event_handles_db_error(pool):
+    """Analytics recording should not raise even if DB fails."""
+    pool.acquire.side_effect = Exception("DB down")
+
+    # Should not raise
+    await record_analytics_event(pool, "view_entry", target_did="did:plc:abc", target_rkey="3xyz")
+
+
+# ---------------------------------------------------------------------------
+# fire_analytics_event (fire-and-forget)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fire_analytics_event_creates_background_task(pool):
+    with patch("atdata_app.database.record_analytics_event", new_callable=AsyncMock) as mock_record:
+        fire_analytics_event(pool, "view_entry", target_did="did:plc:abc", target_rkey="3xyz")
+
+        # Allow the background task to run
+        await asyncio.sleep(0.01)
+
+        mock_record.assert_called_once_with(
+            pool, "view_entry", "did:plc:abc", "3xyz", None
+        )
+
+
+# ---------------------------------------------------------------------------
+# getAnalytics endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch(f"{_DB}.query_analytics_summary", new_callable=AsyncMock)
+@patch(f"{_DB}.fire_analytics_event")
+async def test_get_analytics_endpoint(mock_fire, mock_summary, config, pool):
+    mock_summary.return_value = {
+        "totalViews": 100,
+        "totalSearches": 25,
+        "topDatasets": [
+            {
+                "uri": "at://did:plc:abc/ac.foundation.dataset.record/3xyz",
+                "did": "did:plc:abc",
+                "rkey": "3xyz",
+                "name": "test-ds",
+                "views": 50,
+            }
+        ],
+        "topSearchTerms": [{"term": "genomics", "count": 10}],
+        "recordCounts": {
+            "ac.foundation.dataset.schema": 5,
+            "ac.foundation.dataset.record": 20,
+            "ac.foundation.dataset.label": 10,
+            "ac.foundation.dataset.lens": 3,
+        },
+    }
+
+    app = _mock_app(config, pool)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/xrpc/ac.foundation.dataset.getAnalytics", params={"period": "week"})
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["totalViews"] == 100
+    assert data["totalSearches"] == 25
+    assert len(data["topDatasets"]) == 1
+    assert data["topDatasets"][0]["name"] == "test-ds"
+    assert len(data["topSearchTerms"]) == 1
+    assert data["recordCounts"]["ac.foundation.dataset.record"] == 20
+
+
+@pytest.mark.asyncio
+@patch(f"{_DB}.query_analytics_summary", new_callable=AsyncMock)
+@patch(f"{_DB}.fire_analytics_event")
+async def test_get_analytics_default_period(mock_fire, mock_summary, config, pool):
+    mock_summary.return_value = {
+        "totalViews": 0,
+        "totalSearches": 0,
+        "topDatasets": [],
+        "topSearchTerms": [],
+        "recordCounts": {},
+    }
+
+    app = _mock_app(config, pool)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/xrpc/ac.foundation.dataset.getAnalytics")
+
+    assert resp.status_code == 200
+    mock_summary.assert_called_once_with(pool, "week")
+
+
+@pytest.mark.asyncio
+@patch(f"{_DB}.fire_analytics_event")
+async def test_get_analytics_invalid_period(mock_fire, config, pool):
+    app = _mock_app(config, pool)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/xrpc/ac.foundation.dataset.getAnalytics", params={"period": "year"})
+
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# getEntryStats endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch(f"{_DB}.query_entry_stats", new_callable=AsyncMock)
+@patch(f"{_DB}.fire_analytics_event")
+async def test_get_entry_stats_endpoint(mock_fire, mock_stats, config, pool):
+    mock_stats.return_value = {
+        "views": 42,
+        "searchAppearances": 7,
+        "period": "week",
+    }
+
+    app = _mock_app(config, pool)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/xrpc/ac.foundation.dataset.getEntryStats",
+            params={"uri": "at://did:plc:abc/ac.foundation.dataset.record/3xyz"},
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["views"] == 42
+    assert data["searchAppearances"] == 7
+    assert data["period"] == "week"
+
+
+@pytest.mark.asyncio
+@patch(f"{_DB}.fire_analytics_event")
+async def test_get_entry_stats_invalid_uri(mock_fire, config, pool):
+    app = _mock_app(config, pool)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/xrpc/ac.foundation.dataset.getEntryStats",
+            params={"uri": "https://bad-uri"},
+        )
+
+    assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# describeService includes analytics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch(f"{_DB}.query_active_publishers", new_callable=AsyncMock)
+@patch(f"{_DB}.query_analytics_summary", new_callable=AsyncMock)
+@patch(f"{_DB}.query_record_counts", new_callable=AsyncMock)
+@patch(f"{_DB}.fire_analytics_event")
+async def test_describe_service_includes_analytics(
+    mock_fire, mock_counts, mock_summary, mock_publishers, config, pool
+):
+    mock_counts.return_value = {
+        "ac.foundation.dataset.schema": 5,
+        "ac.foundation.dataset.record": 20,
+        "ac.foundation.dataset.label": 10,
+        "ac.foundation.dataset.lens": 3,
+    }
+    mock_summary.return_value = {
+        "totalViews": 200,
+        "totalSearches": 50,
+        "topDatasets": [],
+        "topSearchTerms": [],
+        "recordCounts": {},
+    }
+    mock_publishers.return_value = 8
+
+    app = _mock_app(config, pool)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/xrpc/ac.foundation.dataset.describeService")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "analytics" in data
+    assert data["analytics"]["totalViews"] == 200
+    assert data["analytics"]["totalSearches"] == 50
+    assert data["analytics"]["activePublishers"] == 8
+
+
+# ---------------------------------------------------------------------------
+# Analytics recording in query endpoints
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch(f"{_DB}.fire_analytics_event")
+@patch(f"{_DB}.query_get_entry", new_callable=AsyncMock)
+async def test_get_entry_fires_analytics(mock_query, mock_fire, config, pool):
+    mock_query.return_value = {
+        "did": "did:plc:abc",
+        "rkey": "3xyz",
+        "cid": "bafytest",
+        "name": "test-ds",
+        "schema_ref": "at://did:plc:abc/ac.foundation.dataset.schema/s@1.0.0",
+        "storage": {"$type": "ac.foundation.dataset.storageHttp"},
+        "description": None,
+        "tags": None,
+        "license": None,
+        "size_samples": None,
+        "size_bytes": None,
+        "size_shards": None,
+        "created_at": "2025-01-01T00:00:00Z",
+    }
+
+    app = _mock_app(config, pool)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/xrpc/ac.foundation.dataset.getEntry",
+            params={"uri": "at://did:plc:abc/ac.foundation.dataset.record/3xyz"},
+        )
+
+    assert resp.status_code == 200
+    mock_fire.assert_called_once_with(
+        pool, "view_entry", target_did="did:plc:abc", target_rkey="3xyz"
+    )
+
+
+@pytest.mark.asyncio
+@patch(f"{_DB}.fire_analytics_event")
+@patch(f"{_DB}.query_search_datasets", new_callable=AsyncMock)
+async def test_search_datasets_fires_analytics(mock_query, mock_fire, config, pool):
+    mock_query.return_value = []
+
+    app = _mock_app(config, pool)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/xrpc/ac.foundation.dataset.searchDatasets",
+            params={"q": "genomics"},
+        )
+
+    assert resp.status_code == 200
+    mock_fire.assert_called_once_with(
+        pool, "search", query_params={"q": "genomics", "tags": None}
+    )
+
+
+# ---------------------------------------------------------------------------
+# Response model validation
+# ---------------------------------------------------------------------------
+
+
+def test_get_analytics_response_model():
+    resp = GetAnalyticsResponse(
+        totalViews=100,
+        totalSearches=25,
+        topDatasets=[{"uri": "at://test", "views": 10}],
+        topSearchTerms=[{"term": "ml", "count": 5}],
+        recordCounts={"ac.foundation.dataset.record": 20},
+    )
+    assert resp.totalViews == 100
+    assert resp.totalSearches == 25
+
+
+def test_get_entry_stats_response_model():
+    resp = GetEntryStatsResponse(views=42, searchAppearances=7, period="week")
+    assert resp.views == 42
+    assert resp.period == "week"
+
+
+def test_describe_service_response_with_analytics():
+    resp = DescribeServiceResponse(
+        did="did:web:localhost%3A8000",
+        availableCollections=["ac.foundation.dataset.record"],
+        recordCount={"ac.foundation.dataset.record": 10},
+        analytics={"totalViews": 50, "totalSearches": 10, "activePublishers": 3},
+    )
+    assert resp.analytics["totalViews"] == 50
+
+
+def test_describe_service_response_without_analytics():
+    resp = DescribeServiceResponse(
+        did="did:web:localhost%3A8000",
+        availableCollections=["ac.foundation.dataset.record"],
+        recordCount={"ac.foundation.dataset.record": 10},
+    )
+    assert resp.analytics is None


### PR DESCRIPTION
## Summary

- Adds `analytics_events` table and `analytics_counters` summary table to track XRPC query usage
- Fire-and-forget event recording via `asyncio.create_task()` — analytics writes never block API responses
- New XRPC endpoints: `getAnalytics` (service-wide stats) and `getEntryStats` (per-dataset stats)
- Extends `describeService` with analytics summary (total views, searches, active publishers)
- Privacy-first: no IP addresses, user agents, or PII recorded — server-side request counting only
- 16 new tests in `test_analytics.py`, all 63 tests passing, linter clean

**Files changed:** `database.py`, `models.py`, `sql/schema.sql`, `xrpc/queries.py`, `tests/test_analytics.py`

## Review notes

- `describeService` awaits analytics queries directly (could use `asyncio.gather` for concurrency)
- `analytics_events` table has no retention policy yet — will need cleanup strategy for production
- Record-counts loop in `query_analytics_summary` duplicates existing `query_record_counts`

## Test plan

- [x] All 63 tests pass (`uv run pytest`)
- [x] Linter clean (`uv run ruff check src/ tests/`)
- [ ] Verify analytics endpoints return expected structure
- [ ] Verify fire-and-forget doesn't block request latency

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)