### PR TITLE
feat: serve separate DID documents for frontend and API hostnames

### DIFF
--- a/src/atdata_app/config.py
+++ b/src/atdata_app/config.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from functools import cached_property
+from typing import Self
 from urllib.parse import quote
 
+from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -21,6 +23,14 @@ class AppConfig(BaseSettings):
     frontend_hostname: str | None = None
     frontend_signing_key: str | None = None
     pds_endpoint: str | None = None
+
+    @model_validator(mode="after")
+    def _check_frontend_config(self) -> Self:
+        if self.frontend_hostname and not self.pds_endpoint:
+            raise ValueError(
+                "ATDATA_PDS_ENDPOINT is required when ATDATA_FRONTEND_HOSTNAME is set"
+            )
+        return self
 
     # Database
     database_url: str = "postgresql://localhost:5432/atdata_app"

--- a/src/atdata_app/config.py
+++ b/src/atdata_app/config.py
@@ -15,6 +15,12 @@ class AppConfig(BaseSettings):
     hostname: str = "localhost"
     port: int = 8000
     dev_mode: bool = True
+    signing_key: str | None = None
+
+    # Frontend identity (optional — enables dual-hostname mode)
+    frontend_hostname: str | None = None
+    frontend_signing_key: str | None = None
+    pds_endpoint: str | None = None
 
     # Database
     database_url: str = "postgresql://localhost:5432/atdata_app"
@@ -37,3 +43,15 @@ class AppConfig(BaseSettings):
         if self.dev_mode:
             return f"http://{self.hostname}:{self.port}"
         return f"https://{self.hostname}"
+
+    @cached_property
+    def frontend_did(self) -> str | None:
+        if not self.frontend_hostname:
+            return None
+        return f"did:web:{self.frontend_hostname}"
+
+    @cached_property
+    def frontend_endpoint(self) -> str | None:
+        if not self.frontend_hostname:
+            return None
+        return f"https://{self.frontend_hostname}"

--- a/src/atdata_app/identity.py
+++ b/src/atdata_app/identity.py
@@ -6,19 +6,64 @@ from fastapi import Request
 from fastapi.responses import JSONResponse
 
 
+def _build_did_document(
+    did: str,
+    service_id: str,
+    service_type: str,
+    service_endpoint: str,
+    signing_key: str | None = None,
+) -> dict:
+    """Build a DID document with optional verificationMethod."""
+    context: list[str] = ["https://www.w3.org/ns/did/v1"]
+    doc: dict = {
+        "@context": context,
+        "id": did,
+        "service": [
+            {
+                "id": service_id,
+                "type": service_type,
+                "serviceEndpoint": service_endpoint,
+            }
+        ],
+    }
+    if signing_key:
+        context.append("https://w3id.org/security/multikey/v1")
+        doc["verificationMethod"] = [
+            {
+                "id": f"{did}#atproto",
+                "type": "Multikey",
+                "controller": did,
+                "publicKeyMultibase": signing_key,
+            }
+        ]
+    return doc
+
+
+def _request_hostname(request: Request) -> str:
+    """Extract hostname from the Host header, stripping port if present."""
+    host = request.headers.get("host", "")
+    return host.split(":")[0]
+
+
 async def did_json_handler(request: Request) -> JSONResponse:
     config = request.app.state.config
-    return JSONResponse(
-        content={
-            "@context": ["https://www.w3.org/ns/did/v1"],
-            "id": config.service_did,
-            "service": [
-                {
-                    "id": "#atproto_appview",
-                    "type": "AtprotoAppView",
-                    "serviceEndpoint": config.service_endpoint,
-                }
-            ],
-        },
-        media_type="application/json",
-    )
+    hostname = _request_hostname(request)
+
+    if config.frontend_hostname and hostname == config.frontend_hostname:
+        doc = _build_did_document(
+            did=config.frontend_did,
+            service_id="#atproto_pds",
+            service_type="AtprotoPersonalDataServer",
+            service_endpoint=config.pds_endpoint or "",
+            signing_key=config.frontend_signing_key,
+        )
+    else:
+        doc = _build_did_document(
+            did=config.service_did,
+            service_id="#atdata_appview",
+            service_type="AtdataAppView",
+            service_endpoint=config.service_endpoint,
+            signing_key=config.signing_key,
+        )
+
+    return JSONResponse(content=doc, media_type="application/json")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,7 @@
 """Tests for AppConfig."""
 
+import pytest
+
 from atdata_app.config import AppConfig
 
 
@@ -21,3 +23,12 @@ def test_service_endpoint_dev():
 def test_service_endpoint_prod():
     config = AppConfig(dev_mode=False, hostname="datasets.atdata.blue")
     assert config.service_endpoint == "https://datasets.atdata.blue"
+
+
+def test_frontend_hostname_requires_pds_endpoint():
+    with pytest.raises(ValueError, match="ATDATA_PDS_ENDPOINT is required"):
+        AppConfig(
+            dev_mode=False,
+            hostname="api.atdata.app",
+            frontend_hostname="atdata.app",
+        )

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -228,6 +228,7 @@ async def test_api_hostname_blocks_frontend_routes():
         dev_mode=False,
         hostname="api.atdata.app",
         frontend_hostname="atdata.app",
+        pds_endpoint="https://pds.foundation.ac",
     )
     app = _make_full_app(config)
 
@@ -246,6 +247,7 @@ async def test_api_hostname_allows_shared_routes():
         dev_mode=False,
         hostname="api.atdata.app",
         frontend_hostname="atdata.app",
+        pds_endpoint="https://pds.foundation.ac",
     )
     app = _make_full_app(config)
 
@@ -316,6 +318,7 @@ def test_frontend_did_property():
         dev_mode=False,
         hostname="api.atdata.app",
         frontend_hostname="atdata.app",
+        pds_endpoint="https://pds.foundation.ac",
     )
     assert config.frontend_did == "did:web:atdata.app"
     assert config.frontend_endpoint == "https://atdata.app"

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -1,4 +1,4 @@
-"""Tests for the DID identity endpoint."""
+"""Tests for the DID identity endpoint and hostname gating."""
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -7,21 +7,43 @@ from atdata_app.config import AppConfig
 from atdata_app.identity import did_json_handler
 
 
-@pytest.fixture
-def _mock_app():
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_app(config: AppConfig):
     """Minimal FastAPI app with just the identity endpoint (no DB)."""
     from fastapi import FastAPI
 
-    config = AppConfig(dev_mode=True, hostname="localhost", port=8000)
     app = FastAPI()
     app.state.config = config
     app.add_api_route("/.well-known/did.json", did_json_handler, methods=["GET"])
     return app
 
 
+def _make_full_app(config: AppConfig):
+    """Full app via create_app (includes middleware and all routes)."""
+    from unittest.mock import AsyncMock
+
+    from atdata_app.main import create_app
+
+    app = create_app(config)
+    app.state.db_pool = AsyncMock()
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Single-hostname mode (dev mode, no frontend_hostname)
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.asyncio
-async def test_did_json(_mock_app):
-    transport = ASGITransport(app=_mock_app)
+async def test_did_json_dev_mode():
+    config = AppConfig(dev_mode=True, hostname="localhost", port=8000)
+    app = _make_app(config)
+
+    transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.get("/.well-known/did.json")
         assert resp.status_code == 200
@@ -31,24 +53,275 @@ async def test_did_json(_mock_app):
         assert len(data["service"]) == 1
 
         svc = data["service"][0]
-        assert svc["id"] == "#atproto_appview"
-        assert svc["type"] == "AtprotoAppView"
+        assert svc["id"] == "#atdata_appview"
+        assert svc["type"] == "AtdataAppView"
         assert svc["serviceEndpoint"] == "http://localhost:8000"
+
+        # No verificationMethod without signing key
+        assert "verificationMethod" not in data
+        assert len(data["@context"]) == 1
 
 
 @pytest.mark.asyncio
 async def test_did_json_production():
-    from fastapi import FastAPI
-
-    config = AppConfig(dev_mode=False, hostname="datasets.atdata.blue")
-    app = FastAPI()
-    app.state.config = config
-    app.add_api_route("/.well-known/did.json", did_json_handler, methods=["GET"])
+    config = AppConfig(dev_mode=False, hostname="api.atdata.app")
+    app = _make_app(config)
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.get("/.well-known/did.json")
         data = resp.json()
 
-        assert data["id"] == "did:web:datasets.atdata.blue"
-        assert data["service"][0]["serviceEndpoint"] == "https://datasets.atdata.blue"
+        assert data["id"] == "did:web:api.atdata.app"
+        assert data["service"][0]["serviceEndpoint"] == "https://api.atdata.app"
+
+
+# ---------------------------------------------------------------------------
+# Dual-hostname mode: API hostname
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_api_hostname_returns_appview_did():
+    config = AppConfig(
+        dev_mode=False,
+        hostname="api.atdata.app",
+        frontend_hostname="atdata.app",
+        pds_endpoint="https://pds.foundation.ac",
+    )
+    app = _make_app(config)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url="http://api.atdata.app"
+    ) as client:
+        resp = await client.get(
+            "/.well-known/did.json", headers={"host": "api.atdata.app"}
+        )
+        data = resp.json()
+
+        assert data["id"] == "did:web:api.atdata.app"
+        svc = data["service"][0]
+        assert svc["id"] == "#atdata_appview"
+        assert svc["type"] == "AtdataAppView"
+        assert svc["serviceEndpoint"] == "https://api.atdata.app"
+
+
+# ---------------------------------------------------------------------------
+# Dual-hostname mode: Frontend hostname
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_frontend_hostname_returns_pds_did():
+    config = AppConfig(
+        dev_mode=False,
+        hostname="api.atdata.app",
+        frontend_hostname="atdata.app",
+        pds_endpoint="https://pds.foundation.ac",
+    )
+    app = _make_app(config)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url="http://atdata.app"
+    ) as client:
+        resp = await client.get(
+            "/.well-known/did.json", headers={"host": "atdata.app"}
+        )
+        data = resp.json()
+
+        assert data["id"] == "did:web:atdata.app"
+        svc = data["service"][0]
+        assert svc["id"] == "#atproto_pds"
+        assert svc["type"] == "AtprotoPersonalDataServer"
+        assert svc["serviceEndpoint"] == "https://pds.foundation.ac"
+
+
+# ---------------------------------------------------------------------------
+# verificationMethod (signing keys)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_appview_did_with_signing_key():
+    config = AppConfig(
+        dev_mode=False,
+        hostname="api.atdata.app",
+        signing_key="zDnaeWgbTFSBnCnPUryHDPSWJPfgt4mM4F1u21Ztc3gTS1Fxk",
+    )
+    app = _make_app(config)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/.well-known/did.json")
+        data = resp.json()
+
+        assert "https://w3id.org/security/multikey/v1" in data["@context"]
+        assert len(data["verificationMethod"]) == 1
+
+        vm = data["verificationMethod"][0]
+        assert vm["id"] == "did:web:api.atdata.app#atproto"
+        assert vm["type"] == "Multikey"
+        assert vm["controller"] == "did:web:api.atdata.app"
+        assert vm["publicKeyMultibase"] == "zDnaeWgbTFSBnCnPUryHDPSWJPfgt4mM4F1u21Ztc3gTS1Fxk"
+
+
+@pytest.mark.asyncio
+async def test_frontend_did_with_signing_key():
+    config = AppConfig(
+        dev_mode=False,
+        hostname="api.atdata.app",
+        frontend_hostname="atdata.app",
+        pds_endpoint="https://pds.foundation.ac",
+        frontend_signing_key="zDnaeABC123frontendkey",
+    )
+    app = _make_app(config)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url="http://atdata.app"
+    ) as client:
+        resp = await client.get(
+            "/.well-known/did.json", headers={"host": "atdata.app"}
+        )
+        data = resp.json()
+
+        assert "https://w3id.org/security/multikey/v1" in data["@context"]
+        vm = data["verificationMethod"][0]
+        assert vm["id"] == "did:web:atdata.app#atproto"
+        assert vm["controller"] == "did:web:atdata.app"
+        assert vm["publicKeyMultibase"] == "zDnaeABC123frontendkey"
+
+
+@pytest.mark.asyncio
+async def test_frontend_did_without_signing_key():
+    config = AppConfig(
+        dev_mode=False,
+        hostname="api.atdata.app",
+        frontend_hostname="atdata.app",
+        pds_endpoint="https://pds.foundation.ac",
+    )
+    app = _make_app(config)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url="http://atdata.app"
+    ) as client:
+        resp = await client.get(
+            "/.well-known/did.json", headers={"host": "atdata.app"}
+        )
+        data = resp.json()
+
+        assert "verificationMethod" not in data
+        assert len(data["@context"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Hostname gating: API hostname must NOT serve frontend routes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_api_hostname_blocks_frontend_routes():
+    config = AppConfig(
+        dev_mode=False,
+        hostname="api.atdata.app",
+        frontend_hostname="atdata.app",
+    )
+    app = _make_full_app(config)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url="http://api.atdata.app"
+    ) as client:
+        for path in ["/", "/about", "/schemas", "/dataset/did:plc:abc/123"]:
+            resp = await client.get(path, headers={"host": "api.atdata.app"})
+            assert resp.status_code == 404, f"Expected 404 for {path} on API host"
+
+
+@pytest.mark.asyncio
+async def test_api_hostname_allows_shared_routes():
+    config = AppConfig(
+        dev_mode=False,
+        hostname="api.atdata.app",
+        frontend_hostname="atdata.app",
+    )
+    app = _make_full_app(config)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url="http://api.atdata.app"
+    ) as client:
+        # Health check
+        resp = await client.get("/health", headers={"host": "api.atdata.app"})
+        assert resp.status_code == 200
+
+        # DID document
+        resp = await client.get(
+            "/.well-known/did.json", headers={"host": "api.atdata.app"}
+        )
+        assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_frontend_hostname_serves_all_routes():
+    """Frontend hostname should serve health, DID, and frontend routes."""
+    config = AppConfig(
+        dev_mode=False,
+        hostname="api.atdata.app",
+        frontend_hostname="atdata.app",
+        pds_endpoint="https://pds.foundation.ac",
+    )
+    app = _make_full_app(config)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url="http://atdata.app"
+    ) as client:
+        # Health check available on frontend host too
+        resp = await client.get("/health", headers={"host": "atdata.app"})
+        assert resp.status_code == 200
+
+        # DID document
+        resp = await client.get(
+            "/.well-known/did.json", headers={"host": "atdata.app"}
+        )
+        assert resp.status_code == 200
+        assert resp.json()["id"] == "did:web:atdata.app"
+
+
+@pytest.mark.asyncio
+async def test_no_frontend_hostname_serves_everything():
+    """When frontend_hostname is not set, all routes are available (dev mode)."""
+    config = AppConfig(dev_mode=True, hostname="localhost", port=8000)
+    app = _make_full_app(config)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/health")
+        assert resp.status_code == 200
+
+        resp = await client.get("/.well-known/did.json")
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Config cached properties
+# ---------------------------------------------------------------------------
+
+
+def test_frontend_did_property():
+    config = AppConfig(
+        dev_mode=False,
+        hostname="api.atdata.app",
+        frontend_hostname="atdata.app",
+    )
+    assert config.frontend_did == "did:web:atdata.app"
+    assert config.frontend_endpoint == "https://atdata.app"
+
+
+def test_frontend_did_property_none_when_unset():
+    config = AppConfig(dev_mode=True, hostname="localhost", port=8000)
+    assert config.frontend_did is None
+    assert config.frontend_endpoint is None


### PR DESCRIPTION
## Summary

- Serve different `did:web` DID documents based on the `Host` header: `api.atdata.app` returns the `AtdataAppView` identity, `atdata.app` returns the atproto PDS account identity
- Gate frontend HTML routes to the frontend hostname only via middleware — the API subdomain serves only XRPC, health, and DID endpoints
- Add optional `verificationMethod` (Multikey) to both DID documents when signing keys are configured
- Validate at startup that `ATDATA_PDS_ENDPOINT` is set when `ATDATA_FRONTEND_HOSTNAME` is configured

## New config vars

| Variable | Purpose |
|---|---|
| `ATDATA_SIGNING_KEY` | Public key multibase for appview DID verificationMethod |
| `ATDATA_FRONTEND_HOSTNAME` | Frontend domain (e.g. `atdata.app`); enables dual-hostname mode |
| `ATDATA_FRONTEND_SIGNING_KEY` | Public key multibase for frontend DID verificationMethod |
| `ATDATA_PDS_ENDPOINT` | PDS service endpoint for frontend DID (required when frontend hostname is set) |

## Test plan

- [x] 143 tests pass (`uv run pytest`)
- [x] Lint clean (`uv run ruff check src/ tests/`)
- [ ] Verify DID documents with both hostnames in staging
- [ ] Confirm frontend routes return 404 on API subdomain
- [ ] Confirm XRPC endpoints work on both hostnames

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)