### PR TITLE
release: v0.2.3b1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,8 @@ jobs:
 
           INSERT INTO entries (did, rkey, name, schema_ref, storage, created_at)
           VALUES ('did:plc:test', '3jqfcqzm3fp2k', 'Test Dataset',
-                  'at://did:plc:test/ac.foundation.dataset.schema/com.example.test@1.0.0',
-                  '{"$type": "ac.foundation.dataset.record#httpStorage", "url": "https://example.com/data.csv"}'::jsonb,
+                  'at://did:plc:test/science.alt.dataset.schema/com.example.test@1.0.0',
+                  '{"$type": "science.alt.dataset.record#httpStorage", "url": "https://example.com/data.csv"}'::jsonb,
                   '2024-01-01T00:00:00Z');
 
           SELECT name FROM entries WHERE search_tsv @@ plainto_tsquery('english'::regconfig, 'Test');

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.2.3b1] - 2026-02-20
+
+### Changed
+
+- **Breaking**: Rename lexicon namespace from `ac.foundation.dataset.*` to `science.alt.dataset.*` across all XRPC endpoints, firehose filters, SQL schema, and configuration ([#17](https://github.com/forecast-bio/atdata-app/issues/17))
+- DID document service entry updated from `#atproto_appview` / `AtprotoAppView` to `#atdata_appview` / `AtdataAppView`
+
+### Added
+
+- Dual-hostname DID document support — serve different `did:web` documents for `api.atdata.app` (appview identity) and `atdata.app` (atproto account identity) based on the `Host` header ([#19](https://github.com/forecast-bio/atdata-app/issues/19))
+- Host-based route gating middleware — frontend HTML routes are only served on the frontend hostname; the API subdomain serves only XRPC, health, and DID endpoints
+- Optional `verificationMethod` (Multikey) in DID documents when signing keys are configured
+- New config vars: `ATDATA_FRONTEND_HOSTNAME`, `ATDATA_PDS_ENDPOINT`, `ATDATA_SIGNING_KEY`, `ATDATA_FRONTEND_SIGNING_KEY`
+- Startup validation requiring `ATDATA_PDS_ENDPOINT` when `ATDATA_FRONTEND_HOSTNAME` is set
+
 ## [0.2.2b1] - 2026-02-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [0.1.0b1] - 2026-02-16
 
-First beta release of the ATProto AppView for `ac.foundation.dataset`.
+First beta release of the ATProto AppView for `science.alt.dataset`.
 
 ### Added
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-ATProto AppView for the `ac.foundation.dataset` lexicon namespace. An AppView is a read-heavy service in the AT Protocol architecture that indexes records from the network firehose and serves them via XRPC endpoints. This one indexes dataset metadata — schemas, dataset entries, labels, and lenses (bidirectional schema transforms).
+ATProto AppView for the `science.alt.dataset` lexicon namespace. An AppView is a read-heavy service in the AT Protocol architecture that indexes records from the network firehose and serves them via XRPC endpoints. This one indexes dataset metadata — schemas, dataset entries, labels, and lenses (bidirectional schema transforms).
 
 ## Commands
 
@@ -45,10 +45,10 @@ Every record type maps to a database table via `database.COLLECTION_TABLE_MAP`:
 
 | Collection | Table | Record key format |
 |---|---|---|
-| `ac.foundation.dataset.schema` | `schemas` | `{NSID}@{semver}` |
-| `ac.foundation.dataset.record` | `entries` | TID |
-| `ac.foundation.dataset.label` | `labels` | TID |
-| `ac.foundation.dataset.lens` | `lenses` | TID |
+| `science.alt.dataset.schema` | `schemas` | `{NSID}@{semver}` |
+| `science.alt.dataset.record` | `entries` | TID |
+| `science.alt.dataset.label` | `labels` | TID |
+| `science.alt.dataset.lens` | `lenses` | TID |
 
 Each has a corresponding `upsert_*` function in `database.py`, a `row_to_*` serializer in `models.py`, and a `publish*` procedure in `xrpc/procedures.py`.
 
@@ -62,7 +62,7 @@ Each has a corresponding `upsert_*` function in `database.py`, a `row_to_*` seri
 
 ### XRPC Endpoints
 
-All mounted under `/xrpc/` via `xrpc/router.py`. Queries are GET, procedures are POST. Endpoint names follow the lexicon NSID pattern (e.g., `/xrpc/ac.foundation.dataset.listEntries`).
+All mounted under `/xrpc/` via `xrpc/router.py`. Queries are GET, procedures are POST. Endpoint names follow the lexicon NSID pattern (e.g., `/xrpc/science.alt.dataset.listEntries`).
 
 ## Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # atdata-app
 
-An [ATProto AppView](https://atproto.com/guides/applications#appview) for the `ac.foundation.dataset` lexicon namespace. It indexes dataset metadata published across the AT Protocol network and serves it through XRPC endpoints — enabling discovery, search, and resolution of datasets, schemas, labels, and lenses.
+An [ATProto AppView](https://atproto.com/guides/applications#appview) for the `science.alt.dataset` lexicon namespace. It indexes dataset metadata published across the AT Protocol network and serves it through XRPC endpoints — enabling discovery, search, and resolution of datasets, schemas, labels, and lenses.
 
 ## Overview
 
@@ -44,7 +44,7 @@ createdb atdata_app
 uv run uvicorn atdata_app.main:app --reload
 ```
 
-The server starts with dev-mode defaults: `http://localhost:8000`, DID `did:web:localhost%3A8000`. On startup it connects to Jetstream and begins indexing `ac.foundation.dataset.*` records, and runs a one-shot backfill of historical records from the BGS relay.
+The server starts with dev-mode defaults: `http://localhost:8000`, DID `did:web:localhost%3A8000`. On startup it connects to Jetstream and begins indexing `science.alt.dataset.*` records, and runs a one-shot backfill of historical records from the BGS relay.
 
 ## Configuration
 
@@ -57,7 +57,7 @@ All settings are environment variables prefixed with `ATDATA_`, managed by [pyda
 | `ATDATA_DEV_MODE` | `true` | Dev mode uses `http://` and includes port in DID; production uses `https://` |
 | `ATDATA_DATABASE_URL` | `postgresql://localhost:5432/atdata_app` | PostgreSQL connection string |
 | `ATDATA_JETSTREAM_URL` | `wss://jetstream2.us-east.bsky.network/subscribe` | Jetstream WebSocket endpoint |
-| `ATDATA_JETSTREAM_COLLECTIONS` | `ac.foundation.dataset.*` | Collections to subscribe to |
+| `ATDATA_JETSTREAM_COLLECTIONS` | `science.alt.dataset.*` | Collections to subscribe to |
 | `ATDATA_RELAY_HOST` | `https://bsky.network` | BGS relay for backfill DID discovery |
 
 ### Identity

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,6 +1,6 @@
 # Data Model
 
-Four tables indexed from the `ac.foundation.dataset.*` namespace, plus cursor state for firehose crash recovery. All tables use `(did, rkey)` as composite primary key. Schema auto-applies on startup.
+Four tables indexed from the `science.alt.dataset.*` namespace, plus cursor state for firehose crash recovery. All tables use `(did, rkey)` as composite primary key. Schema auto-applies on startup.
 
 ## schemas
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "atdata-app"
-version = "0.2.2b1"
+version = "0.2.3b1"
 description = "ATProto AppView for science.alt.dataset"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "atdata-app"
 version = "0.2.2b1"
-description = "ATProto AppView for ac.foundation.dataset"
+description = "ATProto AppView for science.alt.dataset"
 readme = "README.md"
 authors = [
     { name = "Maxine Levesque", email = "hello@maxine.science" },

--- a/src/atdata_app/__init__.py
+++ b/src/atdata_app/__init__.py
@@ -1,4 +1,4 @@
-"""ATProto AppView for ac.foundation.dataset namespace."""
+"""ATProto AppView for science.alt.dataset namespace."""
 
 from __future__ import annotations
 

--- a/src/atdata_app/config.py
+++ b/src/atdata_app/config.py
@@ -21,7 +21,7 @@ class AppConfig(BaseSettings):
 
     # Jetstream
     jetstream_url: str = "wss://jetstream2.us-east.bsky.network/subscribe"
-    jetstream_collections: str = "ac.foundation.dataset.*"
+    jetstream_collections: str = "science.alt.dataset.*"
 
     # Relay (for backfill)
     relay_host: str = "https://bsky.network"

--- a/src/atdata_app/config.py
+++ b/src/atdata_app/config.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from functools import cached_property
+from typing import Self
 from urllib.parse import quote
 
+from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -21,6 +23,14 @@ class AppConfig(BaseSettings):
     frontend_hostname: str | None = None
     frontend_signing_key: str | None = None
     pds_endpoint: str | None = None
+
+    @model_validator(mode="after")
+    def _check_frontend_config(self) -> Self:
+        if self.frontend_hostname and not self.pds_endpoint:
+            raise ValueError(
+                "ATDATA_PDS_ENDPOINT is required when ATDATA_FRONTEND_HOSTNAME is set"
+            )
+        return self
 
     # Database
     database_url: str = "postgresql://localhost:5432/atdata_app"

--- a/src/atdata_app/config.py
+++ b/src/atdata_app/config.py
@@ -15,6 +15,12 @@ class AppConfig(BaseSettings):
     hostname: str = "localhost"
     port: int = 8000
     dev_mode: bool = True
+    signing_key: str | None = None
+
+    # Frontend identity (optional — enables dual-hostname mode)
+    frontend_hostname: str | None = None
+    frontend_signing_key: str | None = None
+    pds_endpoint: str | None = None
 
     # Database
     database_url: str = "postgresql://localhost:5432/atdata_app"
@@ -37,3 +43,15 @@ class AppConfig(BaseSettings):
         if self.dev_mode:
             return f"http://{self.hostname}:{self.port}"
         return f"https://{self.hostname}"
+
+    @cached_property
+    def frontend_did(self) -> str | None:
+        if not self.frontend_hostname:
+            return None
+        return f"did:web:{self.frontend_hostname}"
+
+    @cached_property
+    def frontend_endpoint(self) -> str | None:
+        if not self.frontend_hostname:
+            return None
+        return f"https://{self.frontend_hostname}"

--- a/src/atdata_app/database.py
+++ b/src/atdata_app/database.py
@@ -13,7 +13,7 @@ import asyncpg
 
 logger = logging.getLogger(__name__)
 
-LEXICON_NAMESPACE = "ac.foundation.dataset"
+LEXICON_NAMESPACE = "science.alt.dataset"
 
 COLLECTION_TABLE_MAP: dict[str, str] = {
     f"{LEXICON_NAMESPACE}.schema": "schemas",
@@ -665,7 +665,7 @@ async def query_analytics_summary(
         )
         top_datasets = [
             {
-                "uri": f"at://{r['target_did']}/ac.foundation.dataset.record/{r['target_rkey']}",
+                "uri": f"at://{r['target_did']}/science.alt.dataset.record/{r['target_rkey']}",
                 "did": r["target_did"],
                 "rkey": r["target_rkey"],
                 "name": r["name"] or "",

--- a/src/atdata_app/identity.py
+++ b/src/atdata_app/identity.py
@@ -6,19 +6,64 @@ from fastapi import Request
 from fastapi.responses import JSONResponse
 
 
+def _build_did_document(
+    did: str,
+    service_id: str,
+    service_type: str,
+    service_endpoint: str,
+    signing_key: str | None = None,
+) -> dict:
+    """Build a DID document with optional verificationMethod."""
+    context: list[str] = ["https://www.w3.org/ns/did/v1"]
+    doc: dict = {
+        "@context": context,
+        "id": did,
+        "service": [
+            {
+                "id": service_id,
+                "type": service_type,
+                "serviceEndpoint": service_endpoint,
+            }
+        ],
+    }
+    if signing_key:
+        context.append("https://w3id.org/security/multikey/v1")
+        doc["verificationMethod"] = [
+            {
+                "id": f"{did}#atproto",
+                "type": "Multikey",
+                "controller": did,
+                "publicKeyMultibase": signing_key,
+            }
+        ]
+    return doc
+
+
+def _request_hostname(request: Request) -> str:
+    """Extract hostname from the Host header, stripping port if present."""
+    host = request.headers.get("host", "")
+    return host.split(":")[0]
+
+
 async def did_json_handler(request: Request) -> JSONResponse:
     config = request.app.state.config
-    return JSONResponse(
-        content={
-            "@context": ["https://www.w3.org/ns/did/v1"],
-            "id": config.service_did,
-            "service": [
-                {
-                    "id": "#atproto_appview",
-                    "type": "AtprotoAppView",
-                    "serviceEndpoint": config.service_endpoint,
-                }
-            ],
-        },
-        media_type="application/json",
-    )
+    hostname = _request_hostname(request)
+
+    if config.frontend_hostname and hostname == config.frontend_hostname:
+        doc = _build_did_document(
+            did=config.frontend_did,
+            service_id="#atproto_pds",
+            service_type="AtprotoPersonalDataServer",
+            service_endpoint=config.pds_endpoint or "",
+            signing_key=config.frontend_signing_key,
+        )
+    else:
+        doc = _build_did_document(
+            did=config.service_did,
+            service_id="#atdata_appview",
+            service_type="AtdataAppView",
+            service_endpoint=config.service_endpoint,
+            signing_key=config.signing_key,
+        )
+
+    return JSONResponse(content=doc, media_type="application/json")

--- a/src/atdata_app/ingestion/processor.py
+++ b/src/atdata_app/ingestion/processor.py
@@ -24,7 +24,7 @@ async def process_commit(pool: asyncpg.Pool, event: dict[str, Any]) -> None:
             "commit": {
                 "rev": "...",
                 "operation": "create" | "update" | "delete",
-                "collection": "ac.foundation.dataset.record",
+                "collection": "science.alt.dataset.record",
                 "rkey": "...",
                 "record": { ... },
                 "cid": "..."

--- a/src/atdata_app/mcp_server.py
+++ b/src/atdata_app/mcp_server.py
@@ -54,7 +54,7 @@ async def server_lifespan(server: FastMCP) -> AsyncIterator[ServerContext]:
 mcp_server = FastMCP(
     "atdata",
     instructions=(
-        "ATProto AppView for the ac.foundation.dataset namespace. "
+        "ATProto AppView for the science.alt.dataset namespace. "
         "Use these tools to discover and query scientific datasets, "
         "schemas, and lenses (bidirectional schema transforms) published "
         "on the AT Protocol network."
@@ -106,7 +106,7 @@ async def get_dataset(ctx: Ctx, uri: str) -> dict[str, Any]:
     """Fetch a single dataset entry by its AT-URI.
 
     Args:
-        uri: AT-URI of the dataset (e.g. at://did:plc:abc/ac.foundation.dataset.record/3xyz).
+        uri: AT-URI of the dataset (e.g. at://did:plc:abc/science.alt.dataset.record/3xyz).
 
     Returns:
         Full dataset metadata including name, description, schema ref, storage, tags, and size.
@@ -124,7 +124,7 @@ async def get_schema(ctx: Ctx, uri: str) -> dict[str, Any]:
     """Fetch a schema definition by its AT-URI.
 
     Args:
-        uri: AT-URI of the schema (e.g. at://did:plc:abc/ac.foundation.dataset.schema/my.schema@1.0.0).
+        uri: AT-URI of the schema (e.g. at://did:plc:abc/science.alt.dataset.schema/my.schema@1.0.0).
 
     Returns:
         Full schema record including name, version, type, schema body, and description.

--- a/src/atdata_app/models.py
+++ b/src/atdata_app/models.py
@@ -66,7 +66,7 @@ def maybe_cursor(rows: list, limit: int) -> str | None:
 # ---------------------------------------------------------------------------
 
 
-def row_to_entry(row, collection: str = "ac.foundation.dataset.record") -> dict[str, Any]:
+def row_to_entry(row, collection: str = "science.alt.dataset.record") -> dict[str, Any]:
     uri = make_at_uri(row["did"], collection, row["rkey"])
     storage = row["storage"]
     if isinstance(storage, str):
@@ -102,7 +102,7 @@ def row_to_entry(row, collection: str = "ac.foundation.dataset.record") -> dict[
 
 
 def row_to_schema(row) -> dict[str, Any]:
-    uri = make_at_uri(row["did"], "ac.foundation.dataset.schema", row["rkey"])
+    uri = make_at_uri(row["did"], "science.alt.dataset.schema", row["rkey"])
     schema_body = row["schema_body"]
     if isinstance(schema_body, str):
         schema_body = json.loads(schema_body)
@@ -123,7 +123,7 @@ def row_to_schema(row) -> dict[str, Any]:
 
 
 def row_to_label(row) -> dict[str, Any]:
-    uri = make_at_uri(row["did"], "ac.foundation.dataset.label", row["rkey"])
+    uri = make_at_uri(row["did"], "science.alt.dataset.label", row["rkey"])
     d: dict[str, Any] = {
         "uri": uri,
         "cid": row["cid"],
@@ -139,7 +139,7 @@ def row_to_label(row) -> dict[str, Any]:
 
 
 def row_to_lens(row) -> dict[str, Any]:
-    uri = make_at_uri(row["did"], "ac.foundation.dataset.lens", row["rkey"])
+    uri = make_at_uri(row["did"], "science.alt.dataset.lens", row["rkey"])
     getter_code = row["getter_code"]
     putter_code = row["putter_code"]
     if isinstance(getter_code, str):

--- a/src/atdata_app/sql/schema.sql
+++ b/src/atdata_app/sql/schema.sql
@@ -1,5 +1,5 @@
 -- atdata-app database schema
--- All ac.foundation.dataset.* record types + cursor state
+-- All science.alt.dataset.* record types + cursor state
 
 -- Immutable wrapper for array_to_string(text[], text).
 -- PostgreSQL marks array_to_string as STABLE because the generic anyarray
@@ -11,7 +11,7 @@ RETURNS TEXT LANGUAGE sql IMMUTABLE PARALLEL SAFE AS $$
     SELECT array_to_string(arr, sep)
 $$;
 
--- Schemas (ac.foundation.dataset.schema)
+-- Schemas (science.alt.dataset.schema)
 -- rkey format: {NSID}@{semver}
 CREATE TABLE IF NOT EXISTS schemas (
     did         TEXT NOT NULL,
@@ -31,7 +31,7 @@ CREATE TABLE IF NOT EXISTS schemas (
 CREATE INDEX IF NOT EXISTS idx_schemas_name ON schemas (name);
 CREATE INDEX IF NOT EXISTS idx_schemas_did ON schemas (did);
 
--- Dataset entries (ac.foundation.dataset.record)
+-- Dataset entries (science.alt.dataset.record)
 -- rkey format: TID
 CREATE TABLE IF NOT EXISTS entries (
     did                 TEXT NOT NULL,
@@ -82,7 +82,7 @@ END $$;
 
 CREATE INDEX IF NOT EXISTS idx_entries_search ON entries USING GIN (search_tsv);
 
--- Labels (ac.foundation.dataset.label)
+-- Labels (science.alt.dataset.label)
 CREATE TABLE IF NOT EXISTS labels (
     did         TEXT NOT NULL,
     rkey        TEXT NOT NULL,
@@ -100,7 +100,7 @@ CREATE INDEX IF NOT EXISTS idx_labels_name ON labels (did, name);
 CREATE INDEX IF NOT EXISTS idx_labels_did ON labels (did);
 CREATE INDEX IF NOT EXISTS idx_labels_dataset_uri ON labels (dataset_uri);
 
--- Lenses (ac.foundation.dataset.lens)
+-- Lenses (science.alt.dataset.lens)
 CREATE TABLE IF NOT EXISTS lenses (
     did              TEXT NOT NULL,
     rkey             TEXT NOT NULL,

--- a/src/atdata_app/xrpc/procedures.py
+++ b/src/atdata_app/xrpc/procedures.py
@@ -81,9 +81,9 @@ def _require_pds_token(request: Request) -> str:
 # ---------------------------------------------------------------------------
 
 
-@router.post("/ac.foundation.dataset.publishSchema")
+@router.post("/science.alt.dataset.publishSchema")
 async def publish_schema(request: Request) -> dict[str, Any]:
-    auth = await verify_service_auth(request, "ac.foundation.dataset.publishSchema")
+    auth = await verify_service_auth(request, "science.alt.dataset.publishSchema")
     pds_token = _require_pds_token(request)
     pool = request.app.state.db_pool
 
@@ -93,7 +93,7 @@ async def publish_schema(request: Request) -> dict[str, Any]:
 
     # Validate $type
     record_type = record.get("$type", "")
-    if record_type and record_type != "ac.foundation.dataset.schema":
+    if record_type and record_type != "science.alt.dataset.schema":
         raise HTTPException(status_code=400, detail="Invalid $type for schema")
 
     # Validate required fields
@@ -111,12 +111,12 @@ async def publish_schema(request: Request) -> dict[str, Any]:
             )
 
     # Ensure $type is set
-    record["$type"] = "ac.foundation.dataset.schema"
+    record["$type"] = "science.alt.dataset.schema"
 
     # Proxy to PDS
     pds = await _resolve_pds(auth.iss)
     result = await _proxy_create_record(
-        pds, pds_token, auth.iss, "ac.foundation.dataset.schema", record, rkey
+        pds, pds_token, auth.iss, "science.alt.dataset.schema", record, rkey
     )
     return {"uri": result.get("uri"), "cid": result.get("cid")}
 
@@ -126,9 +126,9 @@ async def publish_schema(request: Request) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-@router.post("/ac.foundation.dataset.publishDataset")
+@router.post("/science.alt.dataset.publishDataset")
 async def publish_dataset(request: Request) -> dict[str, Any]:
-    auth = await verify_service_auth(request, "ac.foundation.dataset.publishDataset")
+    auth = await verify_service_auth(request, "science.alt.dataset.publishDataset")
     pds_token = _require_pds_token(request)
     pool = request.app.state.db_pool
 
@@ -137,7 +137,7 @@ async def publish_dataset(request: Request) -> dict[str, Any]:
     rkey = body.get("rkey")
 
     record_type = record.get("$type", "")
-    if record_type and record_type != "ac.foundation.dataset.record":
+    if record_type and record_type != "science.alt.dataset.record":
         raise HTTPException(status_code=400, detail="Invalid $type for dataset")
 
     for field in ("name", "schemaRef", "storage", "createdAt"):
@@ -160,9 +160,9 @@ async def publish_dataset(request: Request) -> dict[str, Any]:
     # Validate storage $type
     storage = record.get("storage", {})
     valid_storage_types = {
-        "ac.foundation.dataset.storageHttp",
-        "ac.foundation.dataset.storageS3",
-        "ac.foundation.dataset.storageBlobs",
+        "science.alt.dataset.storageHttp",
+        "science.alt.dataset.storageS3",
+        "science.alt.dataset.storageBlobs",
     }
     if storage.get("$type") not in valid_storage_types:
         raise HTTPException(
@@ -170,11 +170,11 @@ async def publish_dataset(request: Request) -> dict[str, Any]:
             detail=f"Invalid storage $type: {storage.get('$type')}",
         )
 
-    record["$type"] = "ac.foundation.dataset.record"
+    record["$type"] = "science.alt.dataset.record"
 
     pds = await _resolve_pds(auth.iss)
     result = await _proxy_create_record(
-        pds, pds_token, auth.iss, "ac.foundation.dataset.record", record, rkey
+        pds, pds_token, auth.iss, "science.alt.dataset.record", record, rkey
     )
     return {"uri": result.get("uri"), "cid": result.get("cid")}
 
@@ -184,9 +184,9 @@ async def publish_dataset(request: Request) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-@router.post("/ac.foundation.dataset.publishLabel")
+@router.post("/science.alt.dataset.publishLabel")
 async def publish_label(request: Request) -> dict[str, Any]:
-    auth = await verify_service_auth(request, "ac.foundation.dataset.publishLabel")
+    auth = await verify_service_auth(request, "science.alt.dataset.publishLabel")
     pds_token = _require_pds_token(request)
     pool = request.app.state.db_pool
 
@@ -195,7 +195,7 @@ async def publish_label(request: Request) -> dict[str, Any]:
     rkey = body.get("rkey")
 
     record_type = record.get("$type", "")
-    if record_type and record_type != "ac.foundation.dataset.label":
+    if record_type and record_type != "science.alt.dataset.label":
         raise HTTPException(status_code=400, detail="Invalid $type for label")
 
     for field in ("name", "datasetUri", "createdAt"):
@@ -215,11 +215,11 @@ async def publish_label(request: Request) -> dict[str, Any]:
             detail=f"Referenced dataset not found: {ds_uri}",
         )
 
-    record["$type"] = "ac.foundation.dataset.label"
+    record["$type"] = "science.alt.dataset.label"
 
     pds = await _resolve_pds(auth.iss)
     result = await _proxy_create_record(
-        pds, pds_token, auth.iss, "ac.foundation.dataset.label", record, rkey
+        pds, pds_token, auth.iss, "science.alt.dataset.label", record, rkey
     )
     return {"uri": result.get("uri"), "cid": result.get("cid")}
 
@@ -229,9 +229,9 @@ async def publish_label(request: Request) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-@router.post("/ac.foundation.dataset.publishLens")
+@router.post("/science.alt.dataset.publishLens")
 async def publish_lens(request: Request) -> dict[str, Any]:
-    auth = await verify_service_auth(request, "ac.foundation.dataset.publishLens")
+    auth = await verify_service_auth(request, "science.alt.dataset.publishLens")
     pds_token = _require_pds_token(request)
     pool = request.app.state.db_pool
 
@@ -240,7 +240,7 @@ async def publish_lens(request: Request) -> dict[str, Any]:
     rkey = body.get("rkey")
 
     record_type = record.get("$type", "")
-    if record_type and record_type != "ac.foundation.dataset.lens":
+    if record_type and record_type != "science.alt.dataset.lens":
         raise HTTPException(status_code=400, detail="Invalid $type for lens")
 
     for field in ("name", "sourceSchema", "targetSchema", "getterCode", "putterCode", "createdAt"):
@@ -261,10 +261,10 @@ async def publish_lens(request: Request) -> dict[str, Any]:
                 detail=f"Referenced schema not found: {uri}",
             )
 
-    record["$type"] = "ac.foundation.dataset.lens"
+    record["$type"] = "science.alt.dataset.lens"
 
     pds = await _resolve_pds(auth.iss)
     result = await _proxy_create_record(
-        pds, pds_token, auth.iss, "ac.foundation.dataset.lens", record, rkey
+        pds, pds_token, auth.iss, "science.alt.dataset.lens", record, rkey
     )
     return {"uri": result.get("uri"), "cid": result.get("cid")}

--- a/src/atdata_app/xrpc/queries.py
+++ b/src/atdata_app/xrpc/queries.py
@@ -68,7 +68,7 @@ async def _resolve_handle(handle: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-@router.get("/ac.foundation.dataset.resolveLabel")
+@router.get("/science.alt.dataset.resolveLabel")
 async def resolve_label(
     request: Request,
     handle: str = Query(...),
@@ -94,7 +94,7 @@ async def resolve_label(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/ac.foundation.dataset.resolveSchema")
+@router.get("/science.alt.dataset.resolveSchema")
 async def resolve_schema(
     request: Request,
     handle: str = Query(...),
@@ -120,7 +120,7 @@ async def resolve_schema(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/ac.foundation.dataset.resolveBlobs")
+@router.get("/science.alt.dataset.resolveBlobs")
 async def resolve_blobs(
     request: Request,
     uris: list[str] = Query(..., max_length=25),
@@ -176,7 +176,7 @@ async def resolve_blobs(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/ac.foundation.dataset.getEntry")
+@router.get("/science.alt.dataset.getEntry")
 async def get_entry(
     request: Request,
     uri: str = Query(...),
@@ -193,7 +193,7 @@ async def get_entry(
     return GetEntryResponse(entry=row_to_entry(row))
 
 
-@router.get("/ac.foundation.dataset.getEntries")
+@router.get("/science.alt.dataset.getEntries")
 async def get_entries(
     request: Request,
     uris: list[str] = Query(..., max_length=25),
@@ -217,7 +217,7 @@ async def get_entries(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/ac.foundation.dataset.getSchema")
+@router.get("/science.alt.dataset.getSchema")
 async def get_schema(
     request: Request,
     uri: str = Query(...),
@@ -239,7 +239,7 @@ async def get_schema(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/ac.foundation.dataset.listEntries")
+@router.get("/science.alt.dataset.listEntries")
 async def list_entries(
     request: Request,
     repo: str | None = Query(None),
@@ -256,7 +256,7 @@ async def list_entries(
     )
 
 
-@router.get("/ac.foundation.dataset.listSchemas")
+@router.get("/science.alt.dataset.listSchemas")
 async def list_schemas(
     request: Request,
     repo: str | None = Query(None),
@@ -273,7 +273,7 @@ async def list_schemas(
     )
 
 
-@router.get("/ac.foundation.dataset.listLenses")
+@router.get("/science.alt.dataset.listLenses")
 async def list_lenses(
     request: Request,
     repo: str | None = Query(None),
@@ -299,7 +299,7 @@ async def list_lenses(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/ac.foundation.dataset.searchDatasets")
+@router.get("/science.alt.dataset.searchDatasets")
 async def search_datasets(
     request: Request,
     q: str = Query(...),
@@ -321,7 +321,7 @@ async def search_datasets(
     )
 
 
-@router.get("/ac.foundation.dataset.searchLenses")
+@router.get("/science.alt.dataset.searchLenses")
 async def search_lenses(
     request: Request,
     sourceSchema: str | None = Query(None),
@@ -345,7 +345,7 @@ async def search_lenses(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/ac.foundation.dataset.describeService")
+@router.get("/science.alt.dataset.describeService")
 async def describe_service(request: Request) -> DescribeServiceResponse:
     config = request.app.state.config
     pool = request.app.state.db_pool
@@ -373,7 +373,7 @@ async def describe_service(request: Request) -> DescribeServiceResponse:
 # ---------------------------------------------------------------------------
 
 
-@router.get("/ac.foundation.dataset.getAnalytics")
+@router.get("/science.alt.dataset.getAnalytics")
 async def get_analytics(
     request: Request,
     period: str = Query("week", pattern="^(day|week|month)$"),
@@ -388,7 +388,7 @@ async def get_analytics(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/ac.foundation.dataset.getEntryStats")
+@router.get("/science.alt.dataset.getEntryStats")
 async def get_entry_stats(
     request: Request,
     uri: str = Query(...),

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -127,7 +127,7 @@ async def test_get_analytics_endpoint(mock_fire, mock_summary, config, pool):
         "totalSearches": 25,
         "topDatasets": [
             {
-                "uri": "at://did:plc:abc/ac.foundation.dataset.record/3xyz",
+                "uri": "at://did:plc:abc/science.alt.dataset.record/3xyz",
                 "did": "did:plc:abc",
                 "rkey": "3xyz",
                 "name": "test-ds",
@@ -136,17 +136,17 @@ async def test_get_analytics_endpoint(mock_fire, mock_summary, config, pool):
         ],
         "topSearchTerms": [{"term": "genomics", "count": 10}],
         "recordCounts": {
-            "ac.foundation.dataset.schema": 5,
-            "ac.foundation.dataset.record": 20,
-            "ac.foundation.dataset.label": 10,
-            "ac.foundation.dataset.lens": 3,
+            "science.alt.dataset.schema": 5,
+            "science.alt.dataset.record": 20,
+            "science.alt.dataset.label": 10,
+            "science.alt.dataset.lens": 3,
         },
     }
 
     app = _mock_app(config, pool)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        resp = await client.get("/xrpc/ac.foundation.dataset.getAnalytics", params={"period": "week"})
+        resp = await client.get("/xrpc/science.alt.dataset.getAnalytics", params={"period": "week"})
 
     assert resp.status_code == 200
     data = resp.json()
@@ -155,7 +155,7 @@ async def test_get_analytics_endpoint(mock_fire, mock_summary, config, pool):
     assert len(data["topDatasets"]) == 1
     assert data["topDatasets"][0]["name"] == "test-ds"
     assert len(data["topSearchTerms"]) == 1
-    assert data["recordCounts"]["ac.foundation.dataset.record"] == 20
+    assert data["recordCounts"]["science.alt.dataset.record"] == 20
 
 
 @pytest.mark.asyncio
@@ -173,7 +173,7 @@ async def test_get_analytics_default_period(mock_fire, mock_summary, config, poo
     app = _mock_app(config, pool)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        resp = await client.get("/xrpc/ac.foundation.dataset.getAnalytics")
+        resp = await client.get("/xrpc/science.alt.dataset.getAnalytics")
 
     assert resp.status_code == 200
     mock_summary.assert_called_once_with(pool, "week")
@@ -185,7 +185,7 @@ async def test_get_analytics_invalid_period(mock_fire, config, pool):
     app = _mock_app(config, pool)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        resp = await client.get("/xrpc/ac.foundation.dataset.getAnalytics", params={"period": "year"})
+        resp = await client.get("/xrpc/science.alt.dataset.getAnalytics", params={"period": "year"})
 
     assert resp.status_code == 422
 
@@ -209,8 +209,8 @@ async def test_get_entry_stats_endpoint(mock_fire, mock_stats, config, pool):
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.get(
-            "/xrpc/ac.foundation.dataset.getEntryStats",
-            params={"uri": "at://did:plc:abc/ac.foundation.dataset.record/3xyz"},
+            "/xrpc/science.alt.dataset.getEntryStats",
+            params={"uri": "at://did:plc:abc/science.alt.dataset.record/3xyz"},
         )
 
     assert resp.status_code == 200
@@ -227,7 +227,7 @@ async def test_get_entry_stats_invalid_uri(mock_fire, config, pool):
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.get(
-            "/xrpc/ac.foundation.dataset.getEntryStats",
+            "/xrpc/science.alt.dataset.getEntryStats",
             params={"uri": "https://bad-uri"},
         )
 
@@ -248,10 +248,10 @@ async def test_describe_service_includes_analytics(
     mock_fire, mock_counts, mock_summary, mock_publishers, config, pool
 ):
     mock_counts.return_value = {
-        "ac.foundation.dataset.schema": 5,
-        "ac.foundation.dataset.record": 20,
-        "ac.foundation.dataset.label": 10,
-        "ac.foundation.dataset.lens": 3,
+        "science.alt.dataset.schema": 5,
+        "science.alt.dataset.record": 20,
+        "science.alt.dataset.label": 10,
+        "science.alt.dataset.lens": 3,
     }
     mock_summary.return_value = {
         "totalViews": 200,
@@ -265,7 +265,7 @@ async def test_describe_service_includes_analytics(
     app = _mock_app(config, pool)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        resp = await client.get("/xrpc/ac.foundation.dataset.describeService")
+        resp = await client.get("/xrpc/science.alt.dataset.describeService")
 
     assert resp.status_code == 200
     data = resp.json()
@@ -289,8 +289,8 @@ async def test_get_entry_fires_analytics(mock_query, mock_fire, config, pool):
         "rkey": "3xyz",
         "cid": "bafytest",
         "name": "test-ds",
-        "schema_ref": "at://did:plc:abc/ac.foundation.dataset.schema/s@1.0.0",
-        "storage": {"$type": "ac.foundation.dataset.storageHttp"},
+        "schema_ref": "at://did:plc:abc/science.alt.dataset.schema/s@1.0.0",
+        "storage": {"$type": "science.alt.dataset.storageHttp"},
         "description": None,
         "tags": None,
         "license": None,
@@ -304,8 +304,8 @@ async def test_get_entry_fires_analytics(mock_query, mock_fire, config, pool):
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.get(
-            "/xrpc/ac.foundation.dataset.getEntry",
-            params={"uri": "at://did:plc:abc/ac.foundation.dataset.record/3xyz"},
+            "/xrpc/science.alt.dataset.getEntry",
+            params={"uri": "at://did:plc:abc/science.alt.dataset.record/3xyz"},
         )
 
     assert resp.status_code == 200
@@ -324,7 +324,7 @@ async def test_search_datasets_fires_analytics(mock_query, mock_fire, config, po
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.get(
-            "/xrpc/ac.foundation.dataset.searchDatasets",
+            "/xrpc/science.alt.dataset.searchDatasets",
             params={"q": "genomics"},
         )
 
@@ -345,7 +345,7 @@ def test_get_analytics_response_model():
         totalSearches=25,
         topDatasets=[{"uri": "at://test", "views": 10}],
         topSearchTerms=[{"term": "ml", "count": 5}],
-        recordCounts={"ac.foundation.dataset.record": 20},
+        recordCounts={"science.alt.dataset.record": 20},
     )
     assert resp.totalViews == 100
     assert resp.totalSearches == 25
@@ -360,8 +360,8 @@ def test_get_entry_stats_response_model():
 def test_describe_service_response_with_analytics():
     resp = DescribeServiceResponse(
         did="did:web:localhost%3A8000",
-        availableCollections=["ac.foundation.dataset.record"],
-        recordCount={"ac.foundation.dataset.record": 10},
+        availableCollections=["science.alt.dataset.record"],
+        recordCount={"science.alt.dataset.record": 10},
         analytics={"totalViews": 50, "totalSearches": 10, "activePublishers": 3},
     )
     assert resp.analytics["totalViews"] == 50
@@ -370,7 +370,7 @@ def test_describe_service_response_with_analytics():
 def test_describe_service_response_without_analytics():
     resp = DescribeServiceResponse(
         did="did:web:localhost%3A8000",
-        availableCollections=["ac.foundation.dataset.record"],
-        recordCount={"ac.foundation.dataset.record": 10},
+        availableCollections=["science.alt.dataset.record"],
+        recordCount={"science.alt.dataset.record": 10},
     )
     assert resp.analytics is None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,7 @@
 """Tests for AppConfig."""
 
+import pytest
+
 from atdata_app.config import AppConfig
 
 
@@ -21,3 +23,12 @@ def test_service_endpoint_dev():
 def test_service_endpoint_prod():
     config = AppConfig(dev_mode=False, hostname="datasets.atdata.blue")
     assert config.service_endpoint == "https://datasets.atdata.blue"
+
+
+def test_frontend_hostname_requires_pds_endpoint():
+    with pytest.raises(ValueError, match="ATDATA_PDS_ENDPOINT is required"):
+        AppConfig(
+            dev_mode=False,
+            hostname="api.atdata.app",
+            frontend_hostname="atdata.app",
+        )

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -22,8 +22,8 @@ def _make_entry_row(
         "rkey": rkey,
         "cid": "bafytest",
         "name": name,
-        "schema_ref": "at://did:plc:test/ac.foundation.dataset.schema/test@1.0.0",
-        "storage": '{"$type": "ac.foundation.dataset.storageHttp", "shards": []}',
+        "schema_ref": "at://did:plc:test/science.alt.dataset.schema/test@1.0.0",
+        "storage": '{"$type": "science.alt.dataset.storageHttp", "shards": []}',
         "description": description,
         "tags": tags or ["ml", "test"],
         "license": "MIT",
@@ -67,7 +67,7 @@ def _make_label_row(
         "rkey": rkey,
         "cid": "bafylabel",
         "name": name,
-        "dataset_uri": "at://did:plc:test123/ac.foundation.dataset.record/3xyz",
+        "dataset_uri": "at://did:plc:test123/science.alt.dataset.record/3xyz",
         "version": "1.0",
         "description": "First version",
         "created_at": "2025-01-01T00:00:00Z",
@@ -246,10 +246,10 @@ async def test_profile(mock_entries, mock_schemas):
 async def test_about(mock_counts):
     pool, _conn = _mock_pool()
     mock_counts.return_value = {
-        "ac.foundation.dataset.schema": 5,
-        "ac.foundation.dataset.record": 10,
-        "ac.foundation.dataset.label": 3,
-        "ac.foundation.dataset.lens": 1,
+        "science.alt.dataset.schema": 5,
+        "science.alt.dataset.record": 10,
+        "science.alt.dataset.label": 3,
+        "science.alt.dataset.lens": 1,
     }
     app = _make_app(pool)
     transport = ASGITransport(app=app)

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -228,6 +228,7 @@ async def test_api_hostname_blocks_frontend_routes():
         dev_mode=False,
         hostname="api.atdata.app",
         frontend_hostname="atdata.app",
+        pds_endpoint="https://pds.foundation.ac",
     )
     app = _make_full_app(config)
 
@@ -246,6 +247,7 @@ async def test_api_hostname_allows_shared_routes():
         dev_mode=False,
         hostname="api.atdata.app",
         frontend_hostname="atdata.app",
+        pds_endpoint="https://pds.foundation.ac",
     )
     app = _make_full_app(config)
 
@@ -316,6 +318,7 @@ def test_frontend_did_property():
         dev_mode=False,
         hostname="api.atdata.app",
         frontend_hostname="atdata.app",
+        pds_endpoint="https://pds.foundation.ac",
     )
     assert config.frontend_did == "did:web:atdata.app"
     assert config.frontend_endpoint == "https://atdata.app"

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -1,4 +1,4 @@
-"""Tests for the DID identity endpoint."""
+"""Tests for the DID identity endpoint and hostname gating."""
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -7,21 +7,43 @@ from atdata_app.config import AppConfig
 from atdata_app.identity import did_json_handler
 
 
-@pytest.fixture
-def _mock_app():
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_app(config: AppConfig):
     """Minimal FastAPI app with just the identity endpoint (no DB)."""
     from fastapi import FastAPI
 
-    config = AppConfig(dev_mode=True, hostname="localhost", port=8000)
     app = FastAPI()
     app.state.config = config
     app.add_api_route("/.well-known/did.json", did_json_handler, methods=["GET"])
     return app
 
 
+def _make_full_app(config: AppConfig):
+    """Full app via create_app (includes middleware and all routes)."""
+    from unittest.mock import AsyncMock
+
+    from atdata_app.main import create_app
+
+    app = create_app(config)
+    app.state.db_pool = AsyncMock()
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Single-hostname mode (dev mode, no frontend_hostname)
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.asyncio
-async def test_did_json(_mock_app):
-    transport = ASGITransport(app=_mock_app)
+async def test_did_json_dev_mode():
+    config = AppConfig(dev_mode=True, hostname="localhost", port=8000)
+    app = _make_app(config)
+
+    transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.get("/.well-known/did.json")
         assert resp.status_code == 200
@@ -31,24 +53,275 @@ async def test_did_json(_mock_app):
         assert len(data["service"]) == 1
 
         svc = data["service"][0]
-        assert svc["id"] == "#atproto_appview"
-        assert svc["type"] == "AtprotoAppView"
+        assert svc["id"] == "#atdata_appview"
+        assert svc["type"] == "AtdataAppView"
         assert svc["serviceEndpoint"] == "http://localhost:8000"
+
+        # No verificationMethod without signing key
+        assert "verificationMethod" not in data
+        assert len(data["@context"]) == 1
 
 
 @pytest.mark.asyncio
 async def test_did_json_production():
-    from fastapi import FastAPI
-
-    config = AppConfig(dev_mode=False, hostname="datasets.atdata.blue")
-    app = FastAPI()
-    app.state.config = config
-    app.add_api_route("/.well-known/did.json", did_json_handler, methods=["GET"])
+    config = AppConfig(dev_mode=False, hostname="api.atdata.app")
+    app = _make_app(config)
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.get("/.well-known/did.json")
         data = resp.json()
 
-        assert data["id"] == "did:web:datasets.atdata.blue"
-        assert data["service"][0]["serviceEndpoint"] == "https://datasets.atdata.blue"
+        assert data["id"] == "did:web:api.atdata.app"
+        assert data["service"][0]["serviceEndpoint"] == "https://api.atdata.app"
+
+
+# ---------------------------------------------------------------------------
+# Dual-hostname mode: API hostname
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_api_hostname_returns_appview_did():
+    config = AppConfig(
+        dev_mode=False,
+        hostname="api.atdata.app",
+        frontend_hostname="atdata.app",
+        pds_endpoint="https://pds.foundation.ac",
+    )
+    app = _make_app(config)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url="http://api.atdata.app"
+    ) as client:
+        resp = await client.get(
+            "/.well-known/did.json", headers={"host": "api.atdata.app"}
+        )
+        data = resp.json()
+
+        assert data["id"] == "did:web:api.atdata.app"
+        svc = data["service"][0]
+        assert svc["id"] == "#atdata_appview"
+        assert svc["type"] == "AtdataAppView"
+        assert svc["serviceEndpoint"] == "https://api.atdata.app"
+
+
+# ---------------------------------------------------------------------------
+# Dual-hostname mode: Frontend hostname
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_frontend_hostname_returns_pds_did():
+    config = AppConfig(
+        dev_mode=False,
+        hostname="api.atdata.app",
+        frontend_hostname="atdata.app",
+        pds_endpoint="https://pds.foundation.ac",
+    )
+    app = _make_app(config)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url="http://atdata.app"
+    ) as client:
+        resp = await client.get(
+            "/.well-known/did.json", headers={"host": "atdata.app"}
+        )
+        data = resp.json()
+
+        assert data["id"] == "did:web:atdata.app"
+        svc = data["service"][0]
+        assert svc["id"] == "#atproto_pds"
+        assert svc["type"] == "AtprotoPersonalDataServer"
+        assert svc["serviceEndpoint"] == "https://pds.foundation.ac"
+
+
+# ---------------------------------------------------------------------------
+# verificationMethod (signing keys)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_appview_did_with_signing_key():
+    config = AppConfig(
+        dev_mode=False,
+        hostname="api.atdata.app",
+        signing_key="zDnaeWgbTFSBnCnPUryHDPSWJPfgt4mM4F1u21Ztc3gTS1Fxk",
+    )
+    app = _make_app(config)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/.well-known/did.json")
+        data = resp.json()
+
+        assert "https://w3id.org/security/multikey/v1" in data["@context"]
+        assert len(data["verificationMethod"]) == 1
+
+        vm = data["verificationMethod"][0]
+        assert vm["id"] == "did:web:api.atdata.app#atproto"
+        assert vm["type"] == "Multikey"
+        assert vm["controller"] == "did:web:api.atdata.app"
+        assert vm["publicKeyMultibase"] == "zDnaeWgbTFSBnCnPUryHDPSWJPfgt4mM4F1u21Ztc3gTS1Fxk"
+
+
+@pytest.mark.asyncio
+async def test_frontend_did_with_signing_key():
+    config = AppConfig(
+        dev_mode=False,
+        hostname="api.atdata.app",
+        frontend_hostname="atdata.app",
+        pds_endpoint="https://pds.foundation.ac",
+        frontend_signing_key="zDnaeABC123frontendkey",
+    )
+    app = _make_app(config)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url="http://atdata.app"
+    ) as client:
+        resp = await client.get(
+            "/.well-known/did.json", headers={"host": "atdata.app"}
+        )
+        data = resp.json()
+
+        assert "https://w3id.org/security/multikey/v1" in data["@context"]
+        vm = data["verificationMethod"][0]
+        assert vm["id"] == "did:web:atdata.app#atproto"
+        assert vm["controller"] == "did:web:atdata.app"
+        assert vm["publicKeyMultibase"] == "zDnaeABC123frontendkey"
+
+
+@pytest.mark.asyncio
+async def test_frontend_did_without_signing_key():
+    config = AppConfig(
+        dev_mode=False,
+        hostname="api.atdata.app",
+        frontend_hostname="atdata.app",
+        pds_endpoint="https://pds.foundation.ac",
+    )
+    app = _make_app(config)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url="http://atdata.app"
+    ) as client:
+        resp = await client.get(
+            "/.well-known/did.json", headers={"host": "atdata.app"}
+        )
+        data = resp.json()
+
+        assert "verificationMethod" not in data
+        assert len(data["@context"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Hostname gating: API hostname must NOT serve frontend routes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_api_hostname_blocks_frontend_routes():
+    config = AppConfig(
+        dev_mode=False,
+        hostname="api.atdata.app",
+        frontend_hostname="atdata.app",
+    )
+    app = _make_full_app(config)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url="http://api.atdata.app"
+    ) as client:
+        for path in ["/", "/about", "/schemas", "/dataset/did:plc:abc/123"]:
+            resp = await client.get(path, headers={"host": "api.atdata.app"})
+            assert resp.status_code == 404, f"Expected 404 for {path} on API host"
+
+
+@pytest.mark.asyncio
+async def test_api_hostname_allows_shared_routes():
+    config = AppConfig(
+        dev_mode=False,
+        hostname="api.atdata.app",
+        frontend_hostname="atdata.app",
+    )
+    app = _make_full_app(config)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url="http://api.atdata.app"
+    ) as client:
+        # Health check
+        resp = await client.get("/health", headers={"host": "api.atdata.app"})
+        assert resp.status_code == 200
+
+        # DID document
+        resp = await client.get(
+            "/.well-known/did.json", headers={"host": "api.atdata.app"}
+        )
+        assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_frontend_hostname_serves_all_routes():
+    """Frontend hostname should serve health, DID, and frontend routes."""
+    config = AppConfig(
+        dev_mode=False,
+        hostname="api.atdata.app",
+        frontend_hostname="atdata.app",
+        pds_endpoint="https://pds.foundation.ac",
+    )
+    app = _make_full_app(config)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url="http://atdata.app"
+    ) as client:
+        # Health check available on frontend host too
+        resp = await client.get("/health", headers={"host": "atdata.app"})
+        assert resp.status_code == 200
+
+        # DID document
+        resp = await client.get(
+            "/.well-known/did.json", headers={"host": "atdata.app"}
+        )
+        assert resp.status_code == 200
+        assert resp.json()["id"] == "did:web:atdata.app"
+
+
+@pytest.mark.asyncio
+async def test_no_frontend_hostname_serves_everything():
+    """When frontend_hostname is not set, all routes are available (dev mode)."""
+    config = AppConfig(dev_mode=True, hostname="localhost", port=8000)
+    app = _make_full_app(config)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/health")
+        assert resp.status_code == 200
+
+        resp = await client.get("/.well-known/did.json")
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Config cached properties
+# ---------------------------------------------------------------------------
+
+
+def test_frontend_did_property():
+    config = AppConfig(
+        dev_mode=False,
+        hostname="api.atdata.app",
+        frontend_hostname="atdata.app",
+    )
+    assert config.frontend_did == "did:web:atdata.app"
+    assert config.frontend_endpoint == "https://atdata.app"
+
+
+def test_frontend_did_property_none_when_unset():
+    config = AppConfig(dev_mode=True, hostname="localhost", port=8000)
+    assert config.frontend_did is None
+    assert config.frontend_endpoint is None

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -14,7 +14,7 @@ _DB = "atdata_app.database"
 
 def _make_event(
     did: str = "did:plc:test123",
-    collection: str = "ac.foundation.dataset.record",
+    collection: str = "science.alt.dataset.record",
     operation: str = "create",
     rkey: str = "3xyz",
     record: dict | None = None,
@@ -30,8 +30,8 @@ def _make_event(
         commit["record"] = record or {
             "$type": collection,
             "name": "test-dataset",
-            "schemaRef": "at://did:plc:test/ac.foundation.dataset.schema/test@1.0.0",
-            "storage": {"$type": "ac.foundation.dataset.storageHttp", "shards": []},
+            "schemaRef": "at://did:plc:test/science.alt.dataset.schema/test@1.0.0",
+            "storage": {"$type": "science.alt.dataset.storageHttp", "shards": []},
             "createdAt": "2025-01-01T00:00:00Z",
         }
         commit["cid"] = cid
@@ -76,13 +76,13 @@ async def test_process_commit_delete(mock_delete):
 async def test_process_commit_schema(mock_upsert):
     pool = AsyncMock()
     event = _make_event(
-        collection="ac.foundation.dataset.schema",
+        collection="science.alt.dataset.schema",
         record={
-            "$type": "ac.foundation.dataset.schema",
+            "$type": "science.alt.dataset.schema",
             "name": "TestSchema",
             "version": "1.0.0",
             "schemaType": "jsonSchema",
-            "schema": {"$type": "ac.foundation.dataset.schema#jsonSchemaFormat"},
+            "schema": {"$type": "science.alt.dataset.schema#jsonSchemaFormat"},
             "createdAt": "2025-01-01T00:00:00Z",
         },
     )
@@ -97,11 +97,11 @@ async def test_process_commit_schema(mock_upsert):
 async def test_process_commit_label(mock_upsert):
     pool = AsyncMock()
     event = _make_event(
-        collection="ac.foundation.dataset.label",
+        collection="science.alt.dataset.label",
         record={
-            "$type": "ac.foundation.dataset.label",
+            "$type": "science.alt.dataset.label",
             "name": "mnist",
-            "datasetUri": "at://did:plc:test/ac.foundation.dataset.record/3xyz",
+            "datasetUri": "at://did:plc:test/science.alt.dataset.record/3xyz",
             "createdAt": "2025-01-01T00:00:00Z",
         },
     )
@@ -116,12 +116,12 @@ async def test_process_commit_label(mock_upsert):
 async def test_process_commit_lens(mock_upsert):
     pool = AsyncMock()
     event = _make_event(
-        collection="ac.foundation.dataset.lens",
+        collection="science.alt.dataset.lens",
         record={
-            "$type": "ac.foundation.dataset.lens",
+            "$type": "science.alt.dataset.lens",
             "name": "test-lens",
-            "sourceSchema": "at://did:plc:test/ac.foundation.dataset.schema/a@1.0.0",
-            "targetSchema": "at://did:plc:test/ac.foundation.dataset.schema/b@1.0.0",
+            "sourceSchema": "at://did:plc:test/science.alt.dataset.schema/a@1.0.0",
+            "targetSchema": "at://did:plc:test/science.alt.dataset.schema/b@1.0.0",
             "getterCode": {"repository": "https://github.com/test/repo", "commit": "abc", "path": "get.py"},
             "putterCode": {"repository": "https://github.com/test/repo", "commit": "abc", "path": "put.py"},
             "createdAt": "2025-01-01T00:00:00Z",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -99,9 +99,9 @@ _SCHEMA_RECORD = {
 
 _ENTRY_RECORD = {
     "name": "Human Genome Variants",
-    "schemaRef": f"at://{_DID_ALICE}/ac.foundation.dataset.schema/com.example.genomics@1.0.0",
+    "schemaRef": f"at://{_DID_ALICE}/science.alt.dataset.schema/com.example.genomics@1.0.0",
     "storage": {
-        "$type": "ac.foundation.dataset.record#httpStorage",
+        "$type": "science.alt.dataset.record#httpStorage",
         "url": "https://example.com/data.parquet",
     },
     "description": "Comprehensive human genome variant dataset for ML research",
@@ -114,7 +114,7 @@ _ENTRY_RECORD = {
 
 _LABEL_RECORD = {
     "name": "v1-stable",
-    "datasetUri": f"at://{_DID_ALICE}/ac.foundation.dataset.record/3jqfcqzm3fp2k",
+    "datasetUri": f"at://{_DID_ALICE}/science.alt.dataset.record/3jqfcqzm3fp2k",
     "version": "1.0",
     "description": "First stable release",
     "createdAt": "2025-02-10T08:00:00Z",
@@ -122,8 +122,8 @@ _LABEL_RECORD = {
 
 _LENS_RECORD = {
     "name": "genomics-to-clinical",
-    "sourceSchema": f"at://{_DID_ALICE}/ac.foundation.dataset.schema/com.example.genomics@1.0.0",
-    "targetSchema": f"at://{_DID_BOB}/ac.foundation.dataset.schema/com.example.clinical@2.0.0",
+    "sourceSchema": f"at://{_DID_ALICE}/science.alt.dataset.schema/com.example.genomics@1.0.0",
+    "targetSchema": f"at://{_DID_BOB}/science.alt.dataset.schema/com.example.clinical@2.0.0",
     "getterCode": {
         "repository": "https://github.com/example/lenses",
         "commit": "abc123",
@@ -631,8 +631,8 @@ class TestQueryFunctions:
         await upsert_lens(db_pool, _DID_BOB, "3jqlens00002", "bafylens2", {
             **_LENS_RECORD,
             "name": "another-lens",
-            "sourceSchema": f"at://{_DID_BOB}/ac.foundation.dataset.schema/x@1.0.0",
-            "targetSchema": f"at://{_DID_BOB}/ac.foundation.dataset.schema/y@1.0.0",
+            "sourceSchema": f"at://{_DID_BOB}/science.alt.dataset.schema/x@1.0.0",
+            "targetSchema": f"at://{_DID_BOB}/science.alt.dataset.schema/y@1.0.0",
         })
 
         all_rows = await query_list_lenses(db_pool, limit=50)
@@ -688,7 +688,7 @@ class TestQueryFunctions:
     async def test_query_labels_for_dataset(self, db_pool):
         from atdata_app.database import query_labels_for_dataset, upsert_label
 
-        ds_uri = f"at://{_DID_ALICE}/ac.foundation.dataset.record/3jqfcqzm3fp2k"
+        ds_uri = f"at://{_DID_ALICE}/science.alt.dataset.record/3jqfcqzm3fp2k"
         await upsert_label(db_pool, _DID_ALICE, "3jqlbl001", "bafylbl1", {
             **_LABEL_RECORD,
             "datasetUri": ds_uri,
@@ -713,10 +713,10 @@ class TestQueryFunctions:
         await upsert_entry(db_pool, _DID_ALICE, "3jqentry00002", "bafye2", _ENTRY_RECORD)
 
         counts = await query_record_counts(db_pool)
-        assert counts["ac.foundation.dataset.schema"] == 1
-        assert counts["ac.foundation.dataset.record"] == 2
-        assert counts["ac.foundation.dataset.label"] == 0
-        assert counts["ac.foundation.dataset.lens"] == 0
+        assert counts["science.alt.dataset.schema"] == 1
+        assert counts["science.alt.dataset.record"] == 2
+        assert counts["science.alt.dataset.label"] == 0
+        assert counts["science.alt.dataset.lens"] == 0
 
     async def test_query_record_exists(self, db_pool):
         from atdata_app.database import query_record_exists, upsert_entry
@@ -836,9 +836,9 @@ class TestSearchLenses:
     async def _seed_lenses(self, db_pool):
         from atdata_app.database import upsert_lens
 
-        src_a = f"at://{_DID_ALICE}/ac.foundation.dataset.schema/a@1.0.0"
-        src_b = f"at://{_DID_ALICE}/ac.foundation.dataset.schema/b@1.0.0"
-        tgt_c = f"at://{_DID_BOB}/ac.foundation.dataset.schema/c@1.0.0"
+        src_a = f"at://{_DID_ALICE}/science.alt.dataset.schema/a@1.0.0"
+        src_b = f"at://{_DID_ALICE}/science.alt.dataset.schema/b@1.0.0"
+        tgt_c = f"at://{_DID_BOB}/science.alt.dataset.schema/c@1.0.0"
 
         await upsert_lens(db_pool, _DID_ALICE, "3jqlens001", "bafyl1", {
             **_LENS_RECORD,
@@ -862,7 +862,7 @@ class TestSearchLenses:
         from atdata_app.database import query_search_lenses
 
         await self._seed_lenses(db_pool)
-        src = f"at://{_DID_ALICE}/ac.foundation.dataset.schema/a@1.0.0"
+        src = f"at://{_DID_ALICE}/science.alt.dataset.schema/a@1.0.0"
         rows = await query_search_lenses(db_pool, source_schema=src, limit=50)
         assert len(rows) == 1
 
@@ -870,8 +870,8 @@ class TestSearchLenses:
         from atdata_app.database import query_search_lenses
 
         await self._seed_lenses(db_pool)
-        src = f"at://{_DID_ALICE}/ac.foundation.dataset.schema/a@1.0.0"
-        tgt = f"at://{_DID_BOB}/ac.foundation.dataset.schema/c@1.0.0"
+        src = f"at://{_DID_ALICE}/science.alt.dataset.schema/a@1.0.0"
+        tgt = f"at://{_DID_BOB}/science.alt.dataset.schema/c@1.0.0"
         rows = await query_search_lenses(
             db_pool, source_schema=src, target_schema=tgt, limit=50
         )
@@ -987,7 +987,7 @@ class TestAnalytics:
         assert summary["topDatasets"][0]["did"] == _DID_ALICE
         assert len(summary["topSearchTerms"]) >= 1
         assert summary["topSearchTerms"][0]["term"] == "genomics"
-        assert "ac.foundation.dataset.record" in summary["recordCounts"]
+        assert "science.alt.dataset.record" in summary["recordCounts"]
 
     async def test_query_entry_stats(self, db_pool):
         from atdata_app.database import query_entry_stats, record_analytics_event
@@ -1060,8 +1060,8 @@ class TestEdgeCases:
 
         minimal_record = {
             "name": "Bare Minimum Dataset",
-            "schemaRef": f"at://{_DID_ALICE}/ac.foundation.dataset.schema/s@1.0.0",
-            "storage": {"$type": "ac.foundation.dataset.record#httpStorage"},
+            "schemaRef": f"at://{_DID_ALICE}/science.alt.dataset.schema/s@1.0.0",
+            "storage": {"$type": "science.alt.dataset.record#httpStorage"},
             "createdAt": "2025-01-01T00:00:00Z",
         }
         await upsert_entry(db_pool, _DID_ALICE, "3jqbare00001", "bafybare", minimal_record)

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -28,8 +28,8 @@ _ENTRY_ROW = {
     "rkey": "3xyz",
     "cid": "bafyentry",
     "name": "test-dataset",
-    "schema_ref": "at://did:plc:abc/ac.foundation.dataset.schema/s@1.0.0",
-    "storage": {"$type": "ac.foundation.dataset.storageHttp", "url": "https://example.com"},
+    "schema_ref": "at://did:plc:abc/science.alt.dataset.schema/s@1.0.0",
+    "storage": {"$type": "science.alt.dataset.storageHttp", "url": "https://example.com"},
     "description": "A test dataset",
     "tags": ["ml", "nlp"],
     "license": "MIT",
@@ -56,8 +56,8 @@ _LENS_ROW = {
     "rkey": "3lens",
     "cid": "bafylens",
     "name": "a-to-b",
-    "source_schema": "at://did:plc:abc/ac.foundation.dataset.schema/a@1.0.0",
-    "target_schema": "at://did:plc:abc/ac.foundation.dataset.schema/b@1.0.0",
+    "source_schema": "at://did:plc:abc/science.alt.dataset.schema/a@1.0.0",
+    "target_schema": "at://did:plc:abc/science.alt.dataset.schema/b@1.0.0",
     "getter_code": {"repo": "https://github.com/test/repo", "path": "get.py"},
     "putter_code": {"repo": "https://github.com/test/repo", "path": "put.py"},
     "description": "Transforms A to B",
@@ -96,7 +96,7 @@ async def test_search_datasets_returns_entries(mock_query):
     mock_query.assert_called_once_with(pool, "test", None, None, None, 10)
     assert len(result) == 1
     assert result[0]["name"] == "test-dataset"
-    assert result[0]["uri"] == "at://did:plc:abc/ac.foundation.dataset.record/3xyz"
+    assert result[0]["uri"] == "at://did:plc:abc/science.alt.dataset.record/3xyz"
 
 
 @pytest.mark.asyncio
@@ -110,7 +110,7 @@ async def test_search_datasets_with_filters(mock_query):
         ctx,
         query="genomics",
         tags=["bio"],
-        schema_ref="at://did:plc:x/ac.foundation.dataset.schema/s@1.0.0",
+        schema_ref="at://did:plc:x/science.alt.dataset.schema/s@1.0.0",
         repo="did:plc:x",
         limit=5,
     )
@@ -119,7 +119,7 @@ async def test_search_datasets_with_filters(mock_query):
         pool,
         "genomics",
         ["bio"],
-        "at://did:plc:x/ac.foundation.dataset.schema/s@1.0.0",
+        "at://did:plc:x/science.alt.dataset.schema/s@1.0.0",
         "did:plc:x",
         5,
     )
@@ -153,7 +153,7 @@ async def test_get_dataset_found(mock_query):
     ctx = _make_ctx(pool)
 
     result = await get_dataset(
-        ctx, uri="at://did:plc:abc/ac.foundation.dataset.record/3xyz"
+        ctx, uri="at://did:plc:abc/science.alt.dataset.record/3xyz"
     )
 
     mock_query.assert_called_once_with(pool, "did:plc:abc", "3xyz")
@@ -169,7 +169,7 @@ async def test_get_dataset_not_found(mock_query):
     ctx = _make_ctx(pool)
 
     result = await get_dataset(
-        ctx, uri="at://did:plc:abc/ac.foundation.dataset.record/missing"
+        ctx, uri="at://did:plc:abc/science.alt.dataset.record/missing"
     )
 
     assert result["error"] == "Dataset not found"
@@ -188,7 +188,7 @@ async def test_get_schema_found(mock_query):
     ctx = _make_ctx(pool)
 
     result = await get_schema(
-        ctx, uri="at://did:plc:abc/ac.foundation.dataset.schema/my.schema@1.0.0"
+        ctx, uri="at://did:plc:abc/science.alt.dataset.schema/my.schema@1.0.0"
     )
 
     mock_query.assert_called_once_with(pool, "did:plc:abc", "my.schema@1.0.0")
@@ -204,7 +204,7 @@ async def test_get_schema_not_found(mock_query):
     ctx = _make_ctx(pool)
 
     result = await get_schema(
-        ctx, uri="at://did:plc:abc/ac.foundation.dataset.schema/missing@1.0.0"
+        ctx, uri="at://did:plc:abc/science.alt.dataset.schema/missing@1.0.0"
     )
 
     assert result["error"] == "Schema not found"
@@ -281,15 +281,15 @@ async def test_search_lenses_with_filters(mock_query):
 
     await search_lenses(
         ctx,
-        source_schema="at://did:plc:abc/ac.foundation.dataset.schema/a@1.0.0",
-        target_schema="at://did:plc:abc/ac.foundation.dataset.schema/b@1.0.0",
+        source_schema="at://did:plc:abc/science.alt.dataset.schema/a@1.0.0",
+        target_schema="at://did:plc:abc/science.alt.dataset.schema/b@1.0.0",
         limit=5,
     )
 
     mock_query.assert_called_once_with(
         pool,
-        "at://did:plc:abc/ac.foundation.dataset.schema/a@1.0.0",
-        "at://did:plc:abc/ac.foundation.dataset.schema/b@1.0.0",
+        "at://did:plc:abc/science.alt.dataset.schema/a@1.0.0",
+        "at://did:plc:abc/science.alt.dataset.schema/b@1.0.0",
         5,
     )
 
@@ -314,10 +314,10 @@ async def test_search_lenses_clamps_limit(mock_query):
 @patch(f"{_DB}.query_record_counts", new_callable=AsyncMock)
 async def test_describe_service(mock_counts):
     mock_counts.return_value = {
-        "ac.foundation.dataset.schema": 10,
-        "ac.foundation.dataset.record": 50,
-        "ac.foundation.dataset.label": 30,
-        "ac.foundation.dataset.lens": 5,
+        "science.alt.dataset.schema": 10,
+        "science.alt.dataset.record": 50,
+        "science.alt.dataset.label": 30,
+        "science.alt.dataset.lens": 5,
     }
     pool = AsyncMock()
     ctx = _make_ctx(pool)
@@ -325,5 +325,5 @@ async def test_describe_service(mock_counts):
     result = await describe_service(ctx)
 
     assert result["did"].startswith("did:web:")
-    assert "ac.foundation.dataset.record" in result["availableCollections"]
-    assert result["recordCount"]["ac.foundation.dataset.record"] == 50
+    assert "science.alt.dataset.record" in result["availableCollections"]
+    assert result["recordCount"]["science.alt.dataset.record"] == 50

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -22,9 +22,9 @@ from atdata_app.models import (
 
 
 def test_parse_at_uri():
-    did, collection, rkey = parse_at_uri("at://did:plc:abc123/ac.foundation.dataset.record/3xyz")
+    did, collection, rkey = parse_at_uri("at://did:plc:abc123/science.alt.dataset.record/3xyz")
     assert did == "did:plc:abc123"
-    assert collection == "ac.foundation.dataset.record"
+    assert collection == "science.alt.dataset.record"
     assert rkey == "3xyz"
 
 
@@ -39,12 +39,12 @@ def test_parse_at_uri_too_few_parts():
 
 
 def test_make_at_uri():
-    uri = make_at_uri("did:plc:abc", "ac.foundation.dataset.record", "rkey1")
-    assert uri == "at://did:plc:abc/ac.foundation.dataset.record/rkey1"
+    uri = make_at_uri("did:plc:abc", "science.alt.dataset.record", "rkey1")
+    assert uri == "at://did:plc:abc/science.alt.dataset.record/rkey1"
 
 
 def test_parse_make_roundtrip():
-    uri = "at://did:plc:abc/ac.foundation.dataset.record/rkey1"
+    uri = "at://did:plc:abc/science.alt.dataset.record/rkey1"
     assert make_at_uri(*parse_at_uri(uri)) == uri
 
 
@@ -82,8 +82,8 @@ _ENTRY_ROW_FULL = {
     "rkey": "3xyz",
     "cid": "bafyfull",
     "name": "test-ds",
-    "schema_ref": "at://did:plc:abc/ac.foundation.dataset.schema/s@1.0.0",
-    "storage": {"$type": "ac.foundation.dataset.storageHttp", "url": "https://example.com"},
+    "schema_ref": "at://did:plc:abc/science.alt.dataset.schema/s@1.0.0",
+    "storage": {"$type": "science.alt.dataset.storageHttp", "url": "https://example.com"},
     "description": "A dataset",
     "tags": ["ml", "nlp"],
     "license": "MIT",
@@ -98,8 +98,8 @@ _ENTRY_ROW_MINIMAL = {
     "rkey": "3xyz",
     "cid": "bafymin",
     "name": "bare-ds",
-    "schema_ref": "at://did:plc:abc/ac.foundation.dataset.schema/s@1.0.0",
-    "storage": {"$type": "ac.foundation.dataset.storageHttp"},
+    "schema_ref": "at://did:plc:abc/science.alt.dataset.schema/s@1.0.0",
+    "storage": {"$type": "science.alt.dataset.storageHttp"},
     "description": None,
     "tags": None,
     "license": None,
@@ -112,7 +112,7 @@ _ENTRY_ROW_MINIMAL = {
 
 def test_row_to_entry_full():
     d = row_to_entry(_ENTRY_ROW_FULL)
-    assert d["uri"] == "at://did:plc:abc/ac.foundation.dataset.record/3xyz"
+    assert d["uri"] == "at://did:plc:abc/science.alt.dataset.record/3xyz"
     assert d["schemaRef"] == _ENTRY_ROW_FULL["schema_ref"]
     assert d["description"] == "A dataset"
     assert d["tags"] == ["ml", "nlp"]
@@ -122,7 +122,7 @@ def test_row_to_entry_full():
 
 def test_row_to_entry_minimal_omits_optional_fields():
     d = row_to_entry(_ENTRY_ROW_MINIMAL)
-    assert d["uri"] == "at://did:plc:abc/ac.foundation.dataset.record/3xyz"
+    assert d["uri"] == "at://did:plc:abc/science.alt.dataset.record/3xyz"
     assert "description" not in d
     assert "tags" not in d
     assert "license" not in d
@@ -131,10 +131,10 @@ def test_row_to_entry_minimal_omits_optional_fields():
 
 def test_row_to_entry_json_string_storage():
     """asyncpg may return JSONB as a string; row_to_entry should parse it."""
-    row = {**_ENTRY_ROW_MINIMAL, "storage": '{"$type": "ac.foundation.dataset.storageHttp"}'}
+    row = {**_ENTRY_ROW_MINIMAL, "storage": '{"$type": "science.alt.dataset.storageHttp"}'}
     d = row_to_entry(row)
     assert isinstance(d["storage"], dict)
-    assert d["storage"]["$type"] == "ac.foundation.dataset.storageHttp"
+    assert d["storage"]["$type"] == "science.alt.dataset.storageHttp"
 
 
 # ---------------------------------------------------------------------------
@@ -156,7 +156,7 @@ _SCHEMA_ROW = {
 
 def test_row_to_schema():
     d = row_to_schema(_SCHEMA_ROW)
-    assert d["uri"] == "at://did:plc:abc/ac.foundation.dataset.schema/my.schema@1.0.0"
+    assert d["uri"] == "at://did:plc:abc/science.alt.dataset.schema/my.schema@1.0.0"
     assert d["schemaType"] == "jsonSchema"
     assert d["schema"] == {"type": "object", "properties": {}}
     assert d["description"] == "A schema"
@@ -183,7 +183,7 @@ _LABEL_ROW = {
     "rkey": "3lbl",
     "cid": "bafylabel",
     "name": "v1",
-    "dataset_uri": "at://did:plc:abc/ac.foundation.dataset.record/3xyz",
+    "dataset_uri": "at://did:plc:abc/science.alt.dataset.record/3xyz",
     "version": "1.0.0",
     "description": "First version",
     "created_at": "2025-01-01T00:00:00Z",
@@ -192,7 +192,7 @@ _LABEL_ROW = {
 
 def test_row_to_label():
     d = row_to_label(_LABEL_ROW)
-    assert d["uri"] == "at://did:plc:abc/ac.foundation.dataset.label/3lbl"
+    assert d["uri"] == "at://did:plc:abc/science.alt.dataset.label/3lbl"
     assert d["datasetUri"] == _LABEL_ROW["dataset_uri"]
     assert d["version"] == "1.0.0"
     assert d["description"] == "First version"
@@ -214,8 +214,8 @@ _LENS_ROW = {
     "rkey": "3lens",
     "cid": "bafylens",
     "name": "a-to-b",
-    "source_schema": "at://did:plc:abc/ac.foundation.dataset.schema/a@1.0.0",
-    "target_schema": "at://did:plc:abc/ac.foundation.dataset.schema/b@1.0.0",
+    "source_schema": "at://did:plc:abc/science.alt.dataset.schema/a@1.0.0",
+    "target_schema": "at://did:plc:abc/science.alt.dataset.schema/b@1.0.0",
     "getter_code": {"repo": "https://github.com/test/repo", "path": "get.py"},
     "putter_code": {"repo": "https://github.com/test/repo", "path": "put.py"},
     "description": "Transforms A to B",
@@ -226,7 +226,7 @@ _LENS_ROW = {
 
 def test_row_to_lens():
     d = row_to_lens(_LENS_ROW)
-    assert d["uri"] == "at://did:plc:abc/ac.foundation.dataset.lens/3lens"
+    assert d["uri"] == "at://did:plc:abc/science.alt.dataset.lens/3lens"
     assert d["sourceSchema"] == _LENS_ROW["source_schema"]
     assert d["getterCode"] == _LENS_ROW["getter_code"]
     assert d["description"] == "Transforms A to B"

--- a/uv.lock
+++ b/uv.lock
@@ -75,7 +75,7 @@ wheels = [
 
 [[package]]
 name = "atdata-app"
-version = "0.2.2b1"
+version = "0.2.3b1"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
## Summary

- **Breaking**: Rename lexicon namespace from `ac.foundation.dataset.*` to `science.alt.dataset.*` across all XRPC endpoints, firehose filters, SQL schema, and configuration (#17)
- Dual-hostname DID document support — serve different `did:web` documents for API and frontend hostnames based on `Host` header (#19)
- Host-based route gating middleware — frontend routes restricted to frontend hostname
- Optional `verificationMethod` (Multikey) in DID documents
- New config vars: `ATDATA_FRONTEND_HOSTNAME`, `ATDATA_PDS_ENDPOINT`, `ATDATA_SIGNING_KEY`, `ATDATA_FRONTEND_SIGNING_KEY`
- Startup validation for frontend config dependencies

## Test plan

- [x] 143 unit tests pass (`uv run pytest`)
- [x] Linter clean (`uv run ruff check src/ tests/`)
- [ ] CI passes on this PR
- [ ] Integration tests pass against PostgreSQL 15/16/17

🤖 Generated with [Claude Code](https://claude.com/claude-code)