### PR TITLE
Rename collection NSID from record to entry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
           INSERT INTO entries (did, rkey, name, schema_ref, storage, created_at)
           VALUES ('did:plc:test', '3jqfcqzm3fp2k', 'Test Dataset',
                   'at://did:plc:test/science.alt.dataset.schema/com.example.test@1.0.0',
-                  '{"$type": "science.alt.dataset.record#httpStorage", "url": "https://example.com/data.csv"}'::jsonb,
+                  '{"$type": "science.alt.dataset.entry#httpStorage", "url": "https://example.com/data.csv"}'::jsonb,
                   '2024-01-01T00:00:00Z');
 
           SELECT name FROM entries WHERE search_tsv @@ plainto_tsquery('english'::regconfig, 'Test');

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ Every record type maps to a database table via `database.COLLECTION_TABLE_MAP`:
 | Collection | Table | Record key format |
 |---|---|---|
 | `science.alt.dataset.schema` | `schemas` | `{NSID}@{semver}` |
-| `science.alt.dataset.record` | `entries` | TID |
+| `science.alt.dataset.entry` | `entries` | TID |
 | `science.alt.dataset.label` | `labels` | TID |
 | `science.alt.dataset.lens` | `lenses` | TID |
 

--- a/src/atdata_app/database.py
+++ b/src/atdata_app/database.py
@@ -17,7 +17,7 @@ LEXICON_NAMESPACE = "science.alt.dataset"
 
 COLLECTION_TABLE_MAP: dict[str, str] = {
     f"{LEXICON_NAMESPACE}.schema": "schemas",
-    f"{LEXICON_NAMESPACE}.record": "entries",
+    f"{LEXICON_NAMESPACE}.entry": "entries",
     f"{LEXICON_NAMESPACE}.label": "labels",
     f"{LEXICON_NAMESPACE}.lens": "lenses",
 }
@@ -665,7 +665,7 @@ async def query_analytics_summary(
         )
         top_datasets = [
             {
-                "uri": f"at://{r['target_did']}/science.alt.dataset.record/{r['target_rkey']}",
+                "uri": f"at://{r['target_did']}/science.alt.dataset.entry/{r['target_rkey']}",
                 "did": r["target_did"],
                 "rkey": r["target_rkey"],
                 "name": r["name"] or "",

--- a/src/atdata_app/ingestion/processor.py
+++ b/src/atdata_app/ingestion/processor.py
@@ -24,7 +24,7 @@ async def process_commit(pool: asyncpg.Pool, event: dict[str, Any]) -> None:
             "commit": {
                 "rev": "...",
                 "operation": "create" | "update" | "delete",
-                "collection": "science.alt.dataset.record",
+                "collection": "science.alt.dataset.entry",
                 "rkey": "...",
                 "record": { ... },
                 "cid": "..."

--- a/src/atdata_app/mcp_server.py
+++ b/src/atdata_app/mcp_server.py
@@ -106,7 +106,7 @@ async def get_dataset(ctx: Ctx, uri: str) -> dict[str, Any]:
     """Fetch a single dataset entry by its AT-URI.
 
     Args:
-        uri: AT-URI of the dataset (e.g. at://did:plc:abc/science.alt.dataset.record/3xyz).
+        uri: AT-URI of the dataset (e.g. at://did:plc:abc/science.alt.dataset.entry/3xyz).
 
     Returns:
         Full dataset metadata including name, description, schema ref, storage, tags, and size.

--- a/src/atdata_app/models.py
+++ b/src/atdata_app/models.py
@@ -66,7 +66,7 @@ def maybe_cursor(rows: list, limit: int) -> str | None:
 # ---------------------------------------------------------------------------
 
 
-def row_to_entry(row, collection: str = "science.alt.dataset.record") -> dict[str, Any]:
+def row_to_entry(row, collection: str = "science.alt.dataset.entry") -> dict[str, Any]:
     uri = make_at_uri(row["did"], collection, row["rkey"])
     storage = row["storage"]
     if isinstance(storage, str):

--- a/src/atdata_app/sql/schema.sql
+++ b/src/atdata_app/sql/schema.sql
@@ -31,7 +31,7 @@ CREATE TABLE IF NOT EXISTS schemas (
 CREATE INDEX IF NOT EXISTS idx_schemas_name ON schemas (name);
 CREATE INDEX IF NOT EXISTS idx_schemas_did ON schemas (did);
 
--- Dataset entries (science.alt.dataset.record)
+-- Dataset entries (science.alt.dataset.entry)
 -- rkey format: TID
 CREATE TABLE IF NOT EXISTS entries (
     did                 TEXT NOT NULL,

--- a/src/atdata_app/xrpc/procedures.py
+++ b/src/atdata_app/xrpc/procedures.py
@@ -137,7 +137,7 @@ async def publish_dataset(request: Request) -> dict[str, Any]:
     rkey = body.get("rkey")
 
     record_type = record.get("$type", "")
-    if record_type and record_type != "science.alt.dataset.record":
+    if record_type and record_type != "science.alt.dataset.entry":
         raise HTTPException(status_code=400, detail="Invalid $type for dataset")
 
     for field in ("name", "schemaRef", "storage", "createdAt"):
@@ -170,11 +170,11 @@ async def publish_dataset(request: Request) -> dict[str, Any]:
             detail=f"Invalid storage $type: {storage.get('$type')}",
         )
 
-    record["$type"] = "science.alt.dataset.record"
+    record["$type"] = "science.alt.dataset.entry"
 
     pds = await _resolve_pds(auth.iss)
     result = await _proxy_create_record(
-        pds, pds_token, auth.iss, "science.alt.dataset.record", record, rkey
+        pds, pds_token, auth.iss, "science.alt.dataset.entry", record, rkey
     )
     return {"uri": result.get("uri"), "cid": result.get("cid")}
 

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -127,7 +127,7 @@ async def test_get_analytics_endpoint(mock_fire, mock_summary, config, pool):
         "totalSearches": 25,
         "topDatasets": [
             {
-                "uri": "at://did:plc:abc/science.alt.dataset.record/3xyz",
+                "uri": "at://did:plc:abc/science.alt.dataset.entry/3xyz",
                 "did": "did:plc:abc",
                 "rkey": "3xyz",
                 "name": "test-ds",
@@ -137,7 +137,7 @@ async def test_get_analytics_endpoint(mock_fire, mock_summary, config, pool):
         "topSearchTerms": [{"term": "genomics", "count": 10}],
         "recordCounts": {
             "science.alt.dataset.schema": 5,
-            "science.alt.dataset.record": 20,
+            "science.alt.dataset.entry": 20,
             "science.alt.dataset.label": 10,
             "science.alt.dataset.lens": 3,
         },
@@ -155,7 +155,7 @@ async def test_get_analytics_endpoint(mock_fire, mock_summary, config, pool):
     assert len(data["topDatasets"]) == 1
     assert data["topDatasets"][0]["name"] == "test-ds"
     assert len(data["topSearchTerms"]) == 1
-    assert data["recordCounts"]["science.alt.dataset.record"] == 20
+    assert data["recordCounts"]["science.alt.dataset.entry"] == 20
 
 
 @pytest.mark.asyncio
@@ -210,7 +210,7 @@ async def test_get_entry_stats_endpoint(mock_fire, mock_stats, config, pool):
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.get(
             "/xrpc/science.alt.dataset.getEntryStats",
-            params={"uri": "at://did:plc:abc/science.alt.dataset.record/3xyz"},
+            params={"uri": "at://did:plc:abc/science.alt.dataset.entry/3xyz"},
         )
 
     assert resp.status_code == 200
@@ -249,7 +249,7 @@ async def test_describe_service_includes_analytics(
 ):
     mock_counts.return_value = {
         "science.alt.dataset.schema": 5,
-        "science.alt.dataset.record": 20,
+        "science.alt.dataset.entry": 20,
         "science.alt.dataset.label": 10,
         "science.alt.dataset.lens": 3,
     }
@@ -305,7 +305,7 @@ async def test_get_entry_fires_analytics(mock_query, mock_fire, config, pool):
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.get(
             "/xrpc/science.alt.dataset.getEntry",
-            params={"uri": "at://did:plc:abc/science.alt.dataset.record/3xyz"},
+            params={"uri": "at://did:plc:abc/science.alt.dataset.entry/3xyz"},
         )
 
     assert resp.status_code == 200
@@ -345,7 +345,7 @@ def test_get_analytics_response_model():
         totalSearches=25,
         topDatasets=[{"uri": "at://test", "views": 10}],
         topSearchTerms=[{"term": "ml", "count": 5}],
-        recordCounts={"science.alt.dataset.record": 20},
+        recordCounts={"science.alt.dataset.entry": 20},
     )
     assert resp.totalViews == 100
     assert resp.totalSearches == 25
@@ -360,8 +360,8 @@ def test_get_entry_stats_response_model():
 def test_describe_service_response_with_analytics():
     resp = DescribeServiceResponse(
         did="did:web:localhost%3A8000",
-        availableCollections=["science.alt.dataset.record"],
-        recordCount={"science.alt.dataset.record": 10},
+        availableCollections=["science.alt.dataset.entry"],
+        recordCount={"science.alt.dataset.entry": 10},
         analytics={"totalViews": 50, "totalSearches": 10, "activePublishers": 3},
     )
     assert resp.analytics["totalViews"] == 50
@@ -370,7 +370,7 @@ def test_describe_service_response_with_analytics():
 def test_describe_service_response_without_analytics():
     resp = DescribeServiceResponse(
         did="did:web:localhost%3A8000",
-        availableCollections=["science.alt.dataset.record"],
-        recordCount={"science.alt.dataset.record": 10},
+        availableCollections=["science.alt.dataset.entry"],
+        recordCount={"science.alt.dataset.entry": 10},
     )
     assert resp.analytics is None

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -67,7 +67,7 @@ def _make_label_row(
         "rkey": rkey,
         "cid": "bafylabel",
         "name": name,
-        "dataset_uri": "at://did:plc:test123/science.alt.dataset.record/3xyz",
+        "dataset_uri": "at://did:plc:test123/science.alt.dataset.entry/3xyz",
         "version": "1.0",
         "description": "First version",
         "created_at": "2025-01-01T00:00:00Z",
@@ -247,7 +247,7 @@ async def test_about(mock_counts):
     pool, _conn = _mock_pool()
     mock_counts.return_value = {
         "science.alt.dataset.schema": 5,
-        "science.alt.dataset.record": 10,
+        "science.alt.dataset.entry": 10,
         "science.alt.dataset.label": 3,
         "science.alt.dataset.lens": 1,
     }

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -14,7 +14,7 @@ _DB = "atdata_app.database"
 
 def _make_event(
     did: str = "did:plc:test123",
-    collection: str = "science.alt.dataset.record",
+    collection: str = "science.alt.dataset.entry",
     operation: str = "create",
     rkey: str = "3xyz",
     record: dict | None = None,
@@ -101,7 +101,7 @@ async def test_process_commit_label(mock_upsert):
         record={
             "$type": "science.alt.dataset.label",
             "name": "mnist",
-            "datasetUri": "at://did:plc:test/science.alt.dataset.record/3xyz",
+            "datasetUri": "at://did:plc:test/science.alt.dataset.entry/3xyz",
             "createdAt": "2025-01-01T00:00:00Z",
         },
     )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -101,7 +101,7 @@ _ENTRY_RECORD = {
     "name": "Human Genome Variants",
     "schemaRef": f"at://{_DID_ALICE}/science.alt.dataset.schema/com.example.genomics@1.0.0",
     "storage": {
-        "$type": "science.alt.dataset.record#httpStorage",
+        "$type": "science.alt.dataset.entry#httpStorage",
         "url": "https://example.com/data.parquet",
     },
     "description": "Comprehensive human genome variant dataset for ML research",
@@ -114,7 +114,7 @@ _ENTRY_RECORD = {
 
 _LABEL_RECORD = {
     "name": "v1-stable",
-    "datasetUri": f"at://{_DID_ALICE}/science.alt.dataset.record/3jqfcqzm3fp2k",
+    "datasetUri": f"at://{_DID_ALICE}/science.alt.dataset.entry/3jqfcqzm3fp2k",
     "version": "1.0",
     "description": "First stable release",
     "createdAt": "2025-02-10T08:00:00Z",
@@ -688,7 +688,7 @@ class TestQueryFunctions:
     async def test_query_labels_for_dataset(self, db_pool):
         from atdata_app.database import query_labels_for_dataset, upsert_label
 
-        ds_uri = f"at://{_DID_ALICE}/science.alt.dataset.record/3jqfcqzm3fp2k"
+        ds_uri = f"at://{_DID_ALICE}/science.alt.dataset.entry/3jqfcqzm3fp2k"
         await upsert_label(db_pool, _DID_ALICE, "3jqlbl001", "bafylbl1", {
             **_LABEL_RECORD,
             "datasetUri": ds_uri,
@@ -714,7 +714,7 @@ class TestQueryFunctions:
 
         counts = await query_record_counts(db_pool)
         assert counts["science.alt.dataset.schema"] == 1
-        assert counts["science.alt.dataset.record"] == 2
+        assert counts["science.alt.dataset.entry"] == 2
         assert counts["science.alt.dataset.label"] == 0
         assert counts["science.alt.dataset.lens"] == 0
 
@@ -987,7 +987,7 @@ class TestAnalytics:
         assert summary["topDatasets"][0]["did"] == _DID_ALICE
         assert len(summary["topSearchTerms"]) >= 1
         assert summary["topSearchTerms"][0]["term"] == "genomics"
-        assert "science.alt.dataset.record" in summary["recordCounts"]
+        assert "science.alt.dataset.entry" in summary["recordCounts"]
 
     async def test_query_entry_stats(self, db_pool):
         from atdata_app.database import query_entry_stats, record_analytics_event
@@ -1061,7 +1061,7 @@ class TestEdgeCases:
         minimal_record = {
             "name": "Bare Minimum Dataset",
             "schemaRef": f"at://{_DID_ALICE}/science.alt.dataset.schema/s@1.0.0",
-            "storage": {"$type": "science.alt.dataset.record#httpStorage"},
+            "storage": {"$type": "science.alt.dataset.entry#httpStorage"},
             "createdAt": "2025-01-01T00:00:00Z",
         }
         await upsert_entry(db_pool, _DID_ALICE, "3jqbare00001", "bafybare", minimal_record)

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -96,7 +96,7 @@ async def test_search_datasets_returns_entries(mock_query):
     mock_query.assert_called_once_with(pool, "test", None, None, None, 10)
     assert len(result) == 1
     assert result[0]["name"] == "test-dataset"
-    assert result[0]["uri"] == "at://did:plc:abc/science.alt.dataset.record/3xyz"
+    assert result[0]["uri"] == "at://did:plc:abc/science.alt.dataset.entry/3xyz"
 
 
 @pytest.mark.asyncio
@@ -153,7 +153,7 @@ async def test_get_dataset_found(mock_query):
     ctx = _make_ctx(pool)
 
     result = await get_dataset(
-        ctx, uri="at://did:plc:abc/science.alt.dataset.record/3xyz"
+        ctx, uri="at://did:plc:abc/science.alt.dataset.entry/3xyz"
     )
 
     mock_query.assert_called_once_with(pool, "did:plc:abc", "3xyz")
@@ -169,7 +169,7 @@ async def test_get_dataset_not_found(mock_query):
     ctx = _make_ctx(pool)
 
     result = await get_dataset(
-        ctx, uri="at://did:plc:abc/science.alt.dataset.record/missing"
+        ctx, uri="at://did:plc:abc/science.alt.dataset.entry/missing"
     )
 
     assert result["error"] == "Dataset not found"
@@ -315,7 +315,7 @@ async def test_search_lenses_clamps_limit(mock_query):
 async def test_describe_service(mock_counts):
     mock_counts.return_value = {
         "science.alt.dataset.schema": 10,
-        "science.alt.dataset.record": 50,
+        "science.alt.dataset.entry": 50,
         "science.alt.dataset.label": 30,
         "science.alt.dataset.lens": 5,
     }
@@ -325,5 +325,5 @@ async def test_describe_service(mock_counts):
     result = await describe_service(ctx)
 
     assert result["did"].startswith("did:web:")
-    assert "science.alt.dataset.record" in result["availableCollections"]
-    assert result["recordCount"]["science.alt.dataset.record"] == 50
+    assert "science.alt.dataset.entry" in result["availableCollections"]
+    assert result["recordCount"]["science.alt.dataset.entry"] == 50

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -22,9 +22,9 @@ from atdata_app.models import (
 
 
 def test_parse_at_uri():
-    did, collection, rkey = parse_at_uri("at://did:plc:abc123/science.alt.dataset.record/3xyz")
+    did, collection, rkey = parse_at_uri("at://did:plc:abc123/science.alt.dataset.entry/3xyz")
     assert did == "did:plc:abc123"
-    assert collection == "science.alt.dataset.record"
+    assert collection == "science.alt.dataset.entry"
     assert rkey == "3xyz"
 
 
@@ -39,12 +39,12 @@ def test_parse_at_uri_too_few_parts():
 
 
 def test_make_at_uri():
-    uri = make_at_uri("did:plc:abc", "science.alt.dataset.record", "rkey1")
-    assert uri == "at://did:plc:abc/science.alt.dataset.record/rkey1"
+    uri = make_at_uri("did:plc:abc", "science.alt.dataset.entry", "rkey1")
+    assert uri == "at://did:plc:abc/science.alt.dataset.entry/rkey1"
 
 
 def test_parse_make_roundtrip():
-    uri = "at://did:plc:abc/science.alt.dataset.record/rkey1"
+    uri = "at://did:plc:abc/science.alt.dataset.entry/rkey1"
     assert make_at_uri(*parse_at_uri(uri)) == uri
 
 
@@ -112,7 +112,7 @@ _ENTRY_ROW_MINIMAL = {
 
 def test_row_to_entry_full():
     d = row_to_entry(_ENTRY_ROW_FULL)
-    assert d["uri"] == "at://did:plc:abc/science.alt.dataset.record/3xyz"
+    assert d["uri"] == "at://did:plc:abc/science.alt.dataset.entry/3xyz"
     assert d["schemaRef"] == _ENTRY_ROW_FULL["schema_ref"]
     assert d["description"] == "A dataset"
     assert d["tags"] == ["ml", "nlp"]
@@ -122,7 +122,7 @@ def test_row_to_entry_full():
 
 def test_row_to_entry_minimal_omits_optional_fields():
     d = row_to_entry(_ENTRY_ROW_MINIMAL)
-    assert d["uri"] == "at://did:plc:abc/science.alt.dataset.record/3xyz"
+    assert d["uri"] == "at://did:plc:abc/science.alt.dataset.entry/3xyz"
     assert "description" not in d
     assert "tags" not in d
     assert "license" not in d
@@ -183,7 +183,7 @@ _LABEL_ROW = {
     "rkey": "3lbl",
     "cid": "bafylabel",
     "name": "v1",
-    "dataset_uri": "at://did:plc:abc/science.alt.dataset.record/3xyz",
+    "dataset_uri": "at://did:plc:abc/science.alt.dataset.entry/3xyz",
     "version": "1.0.0",
     "description": "First version",
     "created_at": "2025-01-01T00:00:00Z",


### PR DESCRIPTION
## Summary
- Renames `science.alt.dataset.record` → `science.alt.dataset.entry` across the entire codebase to align with upstream lexicon v0.2.1b1
- Updates all NSID strings, `$type` values, AT-URIs, docstrings, comments, and test data (46 replacements across 14 files)
- Database table name (`entries`) and all Python function/variable names are unchanged — only protocol-level string values changed

## Test plan
- [x] All 143 tests pass (`uv run pytest`)
- [x] Linter clean (`uv run ruff check src/ tests/`)
- [x] Zero remaining occurrences of `science.alt.dataset.record` in `*.py`, `*.sql`, `*.yml`, `*.md`
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)