### PR TITLE
feat: point lexicons/ at forecast-bio/atdata-lexicon via git submodule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
@@ -28,6 +30,8 @@ jobs:
         python-version: ["3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
@@ -56,6 +60,8 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - name: Apply schema
         env:
           PGHOST: localhost
@@ -105,6 +111,8 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lexicons"]
+	path = lexicons
+	url = https://github.com/forecast-bio/atdata-lexicon.git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,16 @@ uv run ruff check src/ tests/
 uv run uvicorn atdata_app.main:app --reload
 ```
 
+## Lexicon Submodule
+
+The `lexicons/` directory is a git submodule pointing to [forecast-bio/atdata-lexicon](https://github.com/forecast-bio/atdata-lexicon), which contains the authoritative `science.alt.dataset.*` lexicon definitions. The submodule is for reference and CI validation — the Python source code does not read lexicon files at runtime.
+
+After cloning, initialize the submodule:
+
+```bash
+git submodule update --init
+```
+
 ## Architecture
 
 ### Data Flow

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ ATProto Network
 # Install dependencies
 uv sync --dev
 
+# Initialize the lexicon submodule
+git submodule update --init
+
 # Set up PostgreSQL (schema auto-applies on startup)
 createdb atdata_app
 
@@ -134,6 +137,16 @@ uv run ruff check src/ tests/
 ```
 
 Tests mock all external dependencies (database, HTTP, identity resolution) using `unittest.mock.AsyncMock`. HTTP endpoint tests use httpx `ASGITransport` for in-process testing without a running server.
+
+### Lexicon Definitions
+
+The `lexicons/` directory is a [git submodule](https://github.com/forecast-bio/atdata-lexicon) containing the authoritative `science.alt.dataset.*` lexicon schemas. Initialize it with:
+
+```bash
+git submodule update --init
+```
+
+The lexicons are for reference and CI validation. The Python source code uses hardcoded NSID constants and does not read the lexicon JSON files at runtime.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Add `forecast-bio/atdata-lexicon` as a git submodule at `lexicons/`, pinned to `v0.2.1b1` (HTTPS URL for CI compatibility)
- Update all `actions/checkout@v4` steps in CI and publish workflows to use `submodules: true`
- Document the submodule in `CLAUDE.md` and `README.md` with init instructions

## Context

Closes #27. The `lexicons/` directory was previously empty. The authoritative lexicon definitions now live in [forecast-bio/atdata-lexicon](https://github.com/forecast-bio/atdata-lexicon). The submodule is for reference and CI validation only — no Python code reads lexicon files at runtime.

## Test plan

- [x] `uv run pytest` — 143 tests pass
- [x] `uv run ruff check src/ tests/` — clean
- [ ] Verify CI clones the submodule correctly (check the checkout step logs)
- [ ] Verify `git clone --recurse-submodules` works for a fresh clone

🤖 Generated with [Claude Code](https://claude.com/claude-code)