### PR TITLE
feat: add sendInteractions XRPC procedure for usage telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - DID document service entry updated from `#atproto_appview` / `AtprotoAppView` to `#atdata_appview` / `AtdataAppView`
 
 ### Added
+- Adversarial review: sendInteractions feature and surrounding code (round 3) (#39)
+- Add sendInteractions XRPC procedure for usage telemetry (#35)
 
 - Dual-hostname DID document support — serve different `did:web` documents for `api.atdata.app` (appview identity) and `atdata.app` (atproto account identity) based on the `Host` header ([#19](https://github.com/forecast-bio/atdata-app/issues/19))
 - Host-based route gating middleware — frontend HTML routes are only served on the frontend hostname; the API subdomain serves only XRPC, health, and DID endpoints

--- a/src/atdata_app/database.py
+++ b/src/atdata_app/database.py
@@ -720,7 +720,10 @@ async def query_entry_stats(
             """
             SELECT
                 COUNT(*) FILTER (WHERE event_type = 'view_entry') AS views,
-                COUNT(*) FILTER (WHERE event_type = 'search') AS search_appearances
+                COUNT(*) FILTER (WHERE event_type = 'search') AS search_appearances,
+                COUNT(*) FILTER (WHERE event_type = 'download') AS downloads,
+                COUNT(*) FILTER (WHERE event_type = 'citation') AS citations,
+                COUNT(*) FILTER (WHERE event_type = 'derivative') AS derivatives
             FROM analytics_events
             WHERE target_did = $1 AND target_rkey = $2
               AND created_at >= NOW() - $3::interval
@@ -732,6 +735,9 @@ async def query_entry_stats(
         return {
             "views": row["views"],
             "searchAppearances": row["search_appearances"],
+            "downloads": row["downloads"],
+            "citations": row["citations"],
+            "derivatives": row["derivatives"],
             "period": period,
         }
 

--- a/src/atdata_app/frontend/routes.py
+++ b/src/atdata_app/frontend/routes.py
@@ -22,6 +22,7 @@ from atdata_app.database import (
 )
 from atdata_app.models import (
     maybe_cursor,
+    parse_at_uri,
     parse_cursor,
     row_to_entry,
     row_to_label,
@@ -100,10 +101,11 @@ async def dataset_detail(request: Request, did: str, rkey: str):
     schema_did = ""
     schema_rkey = ""
     schema_ref = entry.get("schemaRef", "")
-    if schema_ref.startswith("at://"):
-        parts = schema_ref[5:].split("/", 2)
-        if len(parts) == 3:
-            schema_did, _, schema_rkey = parts
+    if schema_ref:
+        try:
+            schema_did, _, schema_rkey = parse_at_uri(schema_ref)
+        except ValueError:
+            pass
 
     # Fetch labels pointing to this dataset
     dataset_uri = entry["uri"]

--- a/src/atdata_app/ingestion/processor.py
+++ b/src/atdata_app/ingestion/processor.py
@@ -48,14 +48,7 @@ async def process_commit(pool: asyncpg.Pool, event: dict[str, Any]) -> None:
         record = commit["record"]
         cid = commit.get("cid")
         try:
-            if table == "schemas":
-                await db.upsert_schema(pool, did, rkey, cid, record)
-            elif table == "entries":
-                await db.upsert_entry(pool, did, rkey, cid, record)
-            elif table == "labels":
-                await db.upsert_label(pool, did, rkey, cid, record)
-            elif table == "lenses":
-                await db.upsert_lens(pool, did, rkey, cid, record)
+            await db.UPSERT_FNS[table](pool, did, rkey, cid, record)
             logger.debug("Upserted %s %s/%s", collection, did, rkey)
         except Exception:
             logger.exception("Failed to upsert %s %s/%s", collection, did, rkey)

--- a/src/atdata_app/models.py
+++ b/src/atdata_app/models.py
@@ -236,4 +236,7 @@ class GetAnalyticsResponse(BaseModel):
 class GetEntryStatsResponse(BaseModel):
     views: int
     searchAppearances: int
+    downloads: int = 0
+    citations: int = 0
+    derivatives: int = 0
     period: str

--- a/src/atdata_app/models.py
+++ b/src/atdata_app/models.py
@@ -127,6 +127,7 @@ def row_to_label(row) -> dict[str, Any]:
     d: dict[str, Any] = {
         "uri": uri,
         "cid": row["cid"],
+        "did": row["did"],
         "name": row["name"],
         "datasetUri": row["dataset_uri"],
         "createdAt": row["created_at"],
@@ -150,6 +151,7 @@ def row_to_lens(row) -> dict[str, Any]:
     d: dict[str, Any] = {
         "uri": uri,
         "cid": row["cid"],
+        "did": row["did"],
         "name": row["name"],
         "sourceSchema": row["source_schema"],
         "targetSchema": row["target_schema"],

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -8,7 +8,6 @@ import pytest
 
 from atdata_app.ingestion.processor import process_commit
 
-# All patches target the `db` module reference used inside processor.py
 _DB = "atdata_app.database"
 
 
@@ -44,15 +43,22 @@ def _make_event(
     }
 
 
+def _patch_upsert(table: str):
+    """Patch a single entry in UPSERT_FNS by table name."""
+    mock = AsyncMock()
+    return patch.dict(f"{_DB}.UPSERT_FNS", {table: mock}), mock
+
+
 @pytest.mark.asyncio
-@patch(f"{_DB}.upsert_entry", new_callable=AsyncMock)
-async def test_process_commit_create(mock_upsert):
-    pool = AsyncMock()
-    event = _make_event(operation="create")
-    await process_commit(pool, event)
-    mock_upsert.assert_called_once_with(
-        pool, "did:plc:test123", "3xyz", "bafytest", event["commit"]["record"]
-    )
+async def test_process_commit_create():
+    patcher, mock_upsert = _patch_upsert("entries")
+    with patcher:
+        pool = AsyncMock()
+        event = _make_event(operation="create")
+        await process_commit(pool, event)
+        mock_upsert.assert_called_once_with(
+            pool, "did:plc:test123", "3xyz", "bafytest", event["commit"]["record"]
+        )
 
 
 @pytest.mark.asyncio
@@ -72,85 +78,89 @@ async def test_process_commit_delete(mock_delete):
 
 
 @pytest.mark.asyncio
-@patch(f"{_DB}.upsert_schema", new_callable=AsyncMock)
-async def test_process_commit_schema(mock_upsert):
-    pool = AsyncMock()
-    event = _make_event(
-        collection="science.alt.dataset.schema",
-        record={
-            "$type": "science.alt.dataset.schema",
-            "name": "TestSchema",
-            "version": "1.0.0",
-            "schemaType": "jsonSchema",
-            "schema": {"$type": "science.alt.dataset.schema#jsonSchemaFormat"},
-            "createdAt": "2025-01-01T00:00:00Z",
-        },
-    )
-    await process_commit(pool, event)
-    mock_upsert.assert_called_once_with(
-        pool, "did:plc:test123", "3xyz", "bafytest", event["commit"]["record"]
-    )
+async def test_process_commit_schema():
+    patcher, mock_upsert = _patch_upsert("schemas")
+    with patcher:
+        pool = AsyncMock()
+        event = _make_event(
+            collection="science.alt.dataset.schema",
+            record={
+                "$type": "science.alt.dataset.schema",
+                "name": "TestSchema",
+                "version": "1.0.0",
+                "schemaType": "jsonSchema",
+                "schema": {"$type": "science.alt.dataset.schema#jsonSchemaFormat"},
+                "createdAt": "2025-01-01T00:00:00Z",
+            },
+        )
+        await process_commit(pool, event)
+        mock_upsert.assert_called_once_with(
+            pool, "did:plc:test123", "3xyz", "bafytest", event["commit"]["record"]
+        )
 
 
 @pytest.mark.asyncio
-@patch(f"{_DB}.upsert_label", new_callable=AsyncMock)
-async def test_process_commit_label(mock_upsert):
-    pool = AsyncMock()
-    event = _make_event(
-        collection="science.alt.dataset.label",
-        record={
-            "$type": "science.alt.dataset.label",
-            "name": "mnist",
-            "datasetUri": "at://did:plc:test/science.alt.dataset.entry/3xyz",
-            "createdAt": "2025-01-01T00:00:00Z",
-        },
-    )
-    await process_commit(pool, event)
-    mock_upsert.assert_called_once_with(
-        pool, "did:plc:test123", "3xyz", "bafytest", event["commit"]["record"]
-    )
+async def test_process_commit_label():
+    patcher, mock_upsert = _patch_upsert("labels")
+    with patcher:
+        pool = AsyncMock()
+        event = _make_event(
+            collection="science.alt.dataset.label",
+            record={
+                "$type": "science.alt.dataset.label",
+                "name": "mnist",
+                "datasetUri": "at://did:plc:test/science.alt.dataset.entry/3xyz",
+                "createdAt": "2025-01-01T00:00:00Z",
+            },
+        )
+        await process_commit(pool, event)
+        mock_upsert.assert_called_once_with(
+            pool, "did:plc:test123", "3xyz", "bafytest", event["commit"]["record"]
+        )
 
 
 @pytest.mark.asyncio
-@patch(f"{_DB}.upsert_lens", new_callable=AsyncMock)
-async def test_process_commit_lens(mock_upsert):
-    pool = AsyncMock()
-    event = _make_event(
-        collection="science.alt.dataset.lens",
-        record={
-            "$type": "science.alt.dataset.lens",
-            "name": "test-lens",
-            "sourceSchema": "at://did:plc:test/science.alt.dataset.schema/a@1.0.0",
-            "targetSchema": "at://did:plc:test/science.alt.dataset.schema/b@1.0.0",
-            "getterCode": {"repository": "https://github.com/test/repo", "commit": "abc", "path": "get.py"},
-            "putterCode": {"repository": "https://github.com/test/repo", "commit": "abc", "path": "put.py"},
-            "createdAt": "2025-01-01T00:00:00Z",
-        },
-    )
-    await process_commit(pool, event)
-    mock_upsert.assert_called_once_with(
-        pool, "did:plc:test123", "3xyz", "bafytest", event["commit"]["record"]
-    )
+async def test_process_commit_lens():
+    patcher, mock_upsert = _patch_upsert("lenses")
+    with patcher:
+        pool = AsyncMock()
+        event = _make_event(
+            collection="science.alt.dataset.lens",
+            record={
+                "$type": "science.alt.dataset.lens",
+                "name": "test-lens",
+                "sourceSchema": "at://did:plc:test/science.alt.dataset.schema/a@1.0.0",
+                "targetSchema": "at://did:plc:test/science.alt.dataset.schema/b@1.0.0",
+                "getterCode": {"repository": "https://github.com/test/repo", "commit": "abc", "path": "get.py"},
+                "putterCode": {"repository": "https://github.com/test/repo", "commit": "abc", "path": "put.py"},
+                "createdAt": "2025-01-01T00:00:00Z",
+            },
+        )
+        await process_commit(pool, event)
+        mock_upsert.assert_called_once_with(
+            pool, "did:plc:test123", "3xyz", "bafytest", event["commit"]["record"]
+        )
 
 
 @pytest.mark.asyncio
-@patch(f"{_DB}.upsert_entry", new_callable=AsyncMock)
-async def test_process_commit_update(mock_upsert):
+async def test_process_commit_update():
     """Update operations should route to the same upsert function as create."""
-    pool = AsyncMock()
-    event = _make_event(operation="update")
-    await process_commit(pool, event)
-    mock_upsert.assert_called_once_with(
-        pool, "did:plc:test123", "3xyz", "bafytest", event["commit"]["record"]
-    )
+    patcher, mock_upsert = _patch_upsert("entries")
+    with patcher:
+        pool = AsyncMock()
+        event = _make_event(operation="update")
+        await process_commit(pool, event)
+        mock_upsert.assert_called_once_with(
+            pool, "did:plc:test123", "3xyz", "bafytest", event["commit"]["record"]
+        )
 
 
 @pytest.mark.asyncio
-@patch(f"{_DB}.upsert_entry", new_callable=AsyncMock)
-async def test_process_commit_upsert_error_is_caught(mock_upsert):
+async def test_process_commit_upsert_error_is_caught():
     """Upsert failures should be logged, not raised."""
-    mock_upsert.side_effect = Exception("db error")
-    pool = AsyncMock()
-    event = _make_event(operation="create")
-    # Should not raise
-    await process_commit(pool, event)
+    mock = AsyncMock(side_effect=Exception("db error"))
+    with patch.dict(f"{_DB}.UPSERT_FNS", {"entries": mock}):
+        pool = AsyncMock()
+        event = _make_event(operation="create")
+        # Should not raise
+        await process_commit(pool, event)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -193,6 +193,7 @@ _LABEL_ROW = {
 def test_row_to_label():
     d = row_to_label(_LABEL_ROW)
     assert d["uri"] == "at://did:plc:abc/science.alt.dataset.label/3lbl"
+    assert d["did"] == "did:plc:abc"
     assert d["datasetUri"] == _LABEL_ROW["dataset_uri"]
     assert d["version"] == "1.0.0"
     assert d["description"] == "First version"
@@ -227,6 +228,7 @@ _LENS_ROW = {
 def test_row_to_lens():
     d = row_to_lens(_LENS_ROW)
     assert d["uri"] == "at://did:plc:abc/science.alt.dataset.lens/3lens"
+    assert d["did"] == "did:plc:abc"
     assert d["sourceSchema"] == _LENS_ROW["source_schema"]
     assert d["getterCode"] == _LENS_ROW["getter_code"]
     assert d["description"] == "Transforms A to B"


### PR DESCRIPTION
## Summary

- Add `science.alt.dataset.sendInteractions` POST endpoint — fire-and-forget batch reporting of `download`, `citation`, and `derivative` interaction events on datasets
- Validate AT-URIs, interaction types, optional ISO 8601 timestamps; cap batch at 100
- Record events via existing `fire_analytics_event()` infrastructure
- Extend `getEntryStats` to surface per-entry interaction counts (downloads, citations, derivatives)

**Adversarial review (round 3):**
- Fix `row_to_label()` / `row_to_lens()` missing `did` field (inconsistent with entry/schema serializers)
- Replace if/elif upsert dispatch in `processor.py` with `UPSERT_FNS` dict lookup
- Deduplicate record count logic between `query_record_counts()` and `query_analytics_summary()`
- Use `parse_at_uri()` in frontend `dataset_detail()` instead of manual string splitting
- Add 14 new tests (11 sendInteractions + 3 edge cases), remove duplicate fixture

## Test plan

- [x] `uv run pytest` — 157 tests pass
- [x] `uv run ruff check src/ tests/` — clean
- [ ] Verify `POST /xrpc/science.alt.dataset.sendInteractions` accepts valid batches and rejects invalid input
- [ ] Verify `GET /xrpc/science.alt.dataset.getEntryStats` returns new `downloads`/`citations`/`derivatives` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)