### PR TITLE
Add skeleton/hydration pattern for third-party dataset indexes

### DIFF
--- a/src/atdata_app/database.py
+++ b/src/atdata_app/database.py
@@ -825,6 +825,8 @@ async def query_active_publishers(pool: asyncpg.Pool, days: int = 30) -> int:
                 SELECT did FROM labels WHERE indexed_at >= NOW() - $1::interval
                 UNION
                 SELECT did FROM lenses WHERE indexed_at >= NOW() - $1::interval
+                UNION
+                SELECT did FROM index_providers WHERE indexed_at >= NOW() - $1::interval
             ) sub
             """,
             interval,

--- a/src/atdata_app/database.py
+++ b/src/atdata_app/database.py
@@ -20,6 +20,7 @@ COLLECTION_TABLE_MAP: dict[str, str] = {
     f"{LEXICON_NAMESPACE}.entry": "entries",
     f"{LEXICON_NAMESPACE}.label": "labels",
     f"{LEXICON_NAMESPACE}.lens": "lenses",
+    f"{LEXICON_NAMESPACE}.index": "index_providers",
 }
 
 
@@ -203,6 +204,36 @@ async def upsert_lens(
         )
 
 
+async def upsert_index_provider(
+    pool: asyncpg.Pool,
+    did: str,
+    rkey: str,
+    cid: str | None,
+    record: dict[str, Any],
+) -> None:
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO index_providers (did, rkey, cid, name, description, endpoint_url,
+                                         created_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7)
+            ON CONFLICT (did, rkey) DO UPDATE SET
+                cid = EXCLUDED.cid,
+                name = EXCLUDED.name,
+                description = EXCLUDED.description,
+                endpoint_url = EXCLUDED.endpoint_url,
+                indexed_at = NOW()
+            """,
+            did,
+            rkey,
+            cid,
+            record["name"],
+            record.get("description"),
+            record["endpointUrl"],
+            record.get("createdAt", ""),
+        )
+
+
 async def delete_record(pool: asyncpg.Pool, table: str, did: str, rkey: str) -> None:
     if table not in COLLECTION_TABLE_MAP.values():
         return
@@ -219,6 +250,7 @@ UPSERT_FNS = {
     "entries": upsert_entry,
     "labels": upsert_label,
     "lenses": upsert_lens,
+    "index_providers": upsert_index_provider,
 }
 
 
@@ -445,6 +477,49 @@ async def query_list_lenses(
     async with pool.acquire() as conn:
         return await conn.fetch(
             f"SELECT * FROM lenses {where} ORDER BY indexed_at DESC, did DESC, rkey DESC LIMIT ${idx}",
+            *params,
+        )
+
+
+async def query_get_index_provider(
+    pool: asyncpg.Pool, did: str, rkey: str
+) -> asyncpg.Record | None:
+    async with pool.acquire() as conn:
+        return await conn.fetchrow(
+            "SELECT * FROM index_providers WHERE did = $1 AND rkey = $2", did, rkey
+        )
+
+
+async def query_list_index_providers(
+    pool: asyncpg.Pool,
+    repo: str | None = None,
+    limit: int = 50,
+    cursor_did: str | None = None,
+    cursor_rkey: str | None = None,
+    cursor_indexed_at: str | None = None,
+) -> list[asyncpg.Record]:
+    conditions: list[str] = []
+    params: list[Any] = []
+    idx = 1
+
+    if repo:
+        conditions.append(f"did = ${idx}")
+        params.append(repo)
+        idx += 1
+
+    if cursor_indexed_at and cursor_did and cursor_rkey:
+        conditions.append(
+            f"(indexed_at, did, rkey) < (${idx}, ${idx + 1}, ${idx + 2})"
+        )
+        params.extend([datetime.fromisoformat(cursor_indexed_at), cursor_did, cursor_rkey])
+        idx += 3
+
+    where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+    params.append(limit)
+
+    async with pool.acquire() as conn:
+        return await conn.fetch(
+            f"SELECT * FROM index_providers {where} ORDER BY indexed_at DESC, did DESC, rkey DESC LIMIT ${idx}",
             *params,
         )
 

--- a/src/atdata_app/ingestion/processor.py
+++ b/src/atdata_app/ingestion/processor.py
@@ -56,6 +56,8 @@ async def process_commit(pool: asyncpg.Pool, event: dict[str, Any]) -> None:
                 await db.upsert_label(pool, did, rkey, cid, record)
             elif table == "lenses":
                 await db.upsert_lens(pool, did, rkey, cid, record)
+            elif table == "index_providers":
+                await db.upsert_index_provider(pool, did, rkey, cid, record)
             logger.debug("Upserted %s %s/%s", collection, did, rkey)
         except Exception:
             logger.exception("Failed to upsert %s %s/%s", collection, did, rkey)

--- a/src/atdata_app/models.py
+++ b/src/atdata_app/models.py
@@ -138,6 +138,21 @@ def row_to_label(row) -> dict[str, Any]:
     return d
 
 
+def row_to_index_provider(row) -> dict[str, Any]:
+    uri = make_at_uri(row["did"], "science.alt.dataset.index", row["rkey"])
+    d: dict[str, Any] = {
+        "uri": uri,
+        "cid": row["cid"],
+        "did": row["did"],
+        "name": row["name"],
+        "endpointUrl": row["endpoint_url"],
+        "createdAt": row["created_at"],
+    }
+    if row["description"]:
+        d["description"] = row["description"]
+    return d
+
+
 def row_to_lens(row) -> dict[str, Any]:
     uri = make_at_uri(row["did"], "science.alt.dataset.lens", row["rkey"])
     getter_code = row["getter_code"]
@@ -237,3 +252,18 @@ class GetEntryStatsResponse(BaseModel):
     views: int
     searchAppearances: int
     period: str
+
+
+class ListIndexesResponse(BaseModel):
+    indexes: list[dict[str, Any]]
+    cursor: str | None = None
+
+
+class IndexSkeletonResponse(BaseModel):
+    items: list[dict[str, Any]]
+    cursor: str | None = None
+
+
+class IndexResponse(BaseModel):
+    items: list[dict[str, Any]]
+    cursor: str | None = None

--- a/src/atdata_app/models.py
+++ b/src/atdata_app/models.py
@@ -127,6 +127,7 @@ def row_to_label(row) -> dict[str, Any]:
     d: dict[str, Any] = {
         "uri": uri,
         "cid": row["cid"],
+        "did": row["did"],
         "name": row["name"],
         "datasetUri": row["dataset_uri"],
         "createdAt": row["created_at"],
@@ -165,6 +166,7 @@ def row_to_lens(row) -> dict[str, Any]:
     d: dict[str, Any] = {
         "uri": uri,
         "cid": row["cid"],
+        "did": row["did"],
         "name": row["name"],
         "sourceSchema": row["source_schema"],
         "targetSchema": row["target_schema"],

--- a/src/atdata_app/sql/schema.sql
+++ b/src/atdata_app/sql/schema.sql
@@ -144,6 +144,22 @@ CREATE INDEX IF NOT EXISTS idx_analytics_events_type_created
 CREATE INDEX IF NOT EXISTS idx_analytics_events_target
     ON analytics_events (target_did, target_rkey, event_type);
 
+-- Index providers (science.alt.dataset.index)
+CREATE TABLE IF NOT EXISTS index_providers (
+    did          TEXT NOT NULL,
+    rkey         TEXT NOT NULL,
+    cid          TEXT,
+    name         TEXT NOT NULL,
+    description  TEXT,
+    endpoint_url TEXT NOT NULL,
+    created_at   TEXT NOT NULL,
+    indexed_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (did, rkey)
+);
+
+CREATE INDEX IF NOT EXISTS idx_index_providers_did ON index_providers (did);
+CREATE INDEX IF NOT EXISTS idx_index_providers_indexed_at ON index_providers (indexed_at DESC);
+
 -- Pre-aggregated analytics counters (avoids expensive COUNT on events table)
 CREATE TABLE IF NOT EXISTS analytics_counters (
     target_did   TEXT NOT NULL,

--- a/src/atdata_app/xrpc/procedures.py
+++ b/src/atdata_app/xrpc/procedures.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 from fastapi import APIRouter, HTTPException, Request
@@ -19,7 +20,6 @@ from atdata_app.database import (
     query_get_schema,
     query_record_exists,
 )
-from urllib.parse import urlparse
 from atdata_app.models import parse_at_uri
 
 logger = logging.getLogger(__name__)

--- a/src/atdata_app/xrpc/queries.py
+++ b/src/atdata_app/xrpc/queries.py
@@ -7,9 +7,9 @@ from typing import Any
 
 from fastapi import APIRouter, HTTPException, Query, Request
 
-from atdata_app import get_resolver
 import httpx
 
+from atdata_app import get_resolver
 from atdata_app.database import (
     COLLECTION_TABLE_MAP,
     fire_analytics_event,

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -132,8 +132,7 @@ async def test_get_index_skeleton_not_found(mock_get_provider):
 
 
 @pytest.mark.asyncio
-@patch(f"{_QUERIES}.query_get_index_provider", new_callable=AsyncMock)
-async def test_get_index_skeleton_invalid_uri(mock_get_provider):
+async def test_get_index_skeleton_invalid_uri():
     app, pool = _make_app()
 
     transport = ASGITransport(app=app)

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,0 +1,541 @@
+"""Tests for index provider endpoints (skeleton/hydration pattern)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from atdata_app.config import AppConfig
+from atdata_app.ingestion.processor import process_commit
+from atdata_app.main import create_app
+
+_DB = "atdata_app.database"
+_QUERIES = "atdata_app.xrpc.queries"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_app() -> tuple:
+    config = AppConfig(dev_mode=True, hostname="localhost", port=8000)
+    app = create_app(config)
+    pool = AsyncMock()
+    app.state.db_pool = pool
+    return app, pool
+
+
+def _index_provider_row(
+    did: str = "did:plc:provider1",
+    rkey: str = "3abc",
+    endpoint_url: str = "https://example.com/skeleton",
+    name: str = "Genomics Index",
+    description: str = "Curated genomics datasets",
+) -> dict:
+    """Simulate an asyncpg Record as a dict-like object."""
+    return MagicMock(
+        **{
+            "__getitem__": lambda self, key: {
+                "did": did,
+                "rkey": rkey,
+                "cid": "bafyindex",
+                "name": name,
+                "description": description,
+                "endpoint_url": endpoint_url,
+                "created_at": "2025-01-01T00:00:00Z",
+                "indexed_at": "2025-01-01T00:00:00+00:00",
+            }[key],
+        }
+    )
+
+
+def _entry_row(did: str = "did:plc:author1", rkey: str = "3xyz") -> MagicMock:
+    return MagicMock(
+        **{
+            "__getitem__": lambda self, key: {
+                "did": did,
+                "rkey": rkey,
+                "cid": "bafyentry",
+                "name": "test-dataset",
+                "schema_ref": "at://did:plc:test/science.alt.dataset.schema/test@1.0.0",
+                "storage": '{"$type": "science.alt.dataset.storageHttp", "shards": []}',
+                "description": None,
+                "tags": None,
+                "license": None,
+                "size_samples": None,
+                "size_bytes": None,
+                "size_shards": None,
+                "created_at": "2025-01-01T00:00:00Z",
+                "indexed_at": "2025-01-01T00:00:00+00:00",
+            }[key],
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# getIndexSkeleton
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch(f"{_QUERIES}.query_get_index_provider", new_callable=AsyncMock)
+async def test_get_index_skeleton_success(mock_get_provider):
+    app, pool = _make_app()
+    mock_get_provider.return_value = _index_provider_row()
+
+    skeleton_response = {
+        "items": [{"uri": "at://did:plc:a/science.alt.dataset.entry/3xyz"}],
+        "cursor": "next123",
+    }
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = skeleton_response
+
+    with patch("atdata_app.xrpc.queries.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_resp
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get(
+                "/xrpc/science.alt.dataset.getIndexSkeleton",
+                params={"index": "at://did:plc:provider1/science.alt.dataset.index/3abc"},
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert len(data["items"]) == 1
+            assert data["items"][0]["uri"] == "at://did:plc:a/science.alt.dataset.entry/3xyz"
+            assert data["cursor"] == "next123"
+
+
+@pytest.mark.asyncio
+@patch(f"{_QUERIES}.query_get_index_provider", new_callable=AsyncMock)
+async def test_get_index_skeleton_not_found(mock_get_provider):
+    app, pool = _make_app()
+    mock_get_provider.return_value = None
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/xrpc/science.alt.dataset.getIndexSkeleton",
+            params={"index": "at://did:plc:missing/science.alt.dataset.index/3abc"},
+        )
+        assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+@patch(f"{_QUERIES}.query_get_index_provider", new_callable=AsyncMock)
+async def test_get_index_skeleton_invalid_uri(mock_get_provider):
+    app, pool = _make_app()
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/xrpc/science.alt.dataset.getIndexSkeleton",
+            params={"index": "not-a-uri"},
+        )
+        assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+@patch(f"{_QUERIES}.query_get_index_provider", new_callable=AsyncMock)
+async def test_get_index_skeleton_upstream_error(mock_get_provider):
+    app, pool = _make_app()
+    mock_get_provider.return_value = _index_provider_row()
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 500
+
+    with patch("atdata_app.xrpc.queries.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_resp
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get(
+                "/xrpc/science.alt.dataset.getIndexSkeleton",
+                params={"index": "at://did:plc:provider1/science.alt.dataset.index/3abc"},
+            )
+            assert resp.status_code == 502
+
+
+@pytest.mark.asyncio
+@patch(f"{_QUERIES}.query_get_index_provider", new_callable=AsyncMock)
+async def test_get_index_skeleton_upstream_unreachable(mock_get_provider):
+    app, pool = _make_app()
+    mock_get_provider.return_value = _index_provider_row()
+
+    with patch("atdata_app.xrpc.queries.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.get.side_effect = httpx.ConnectError("Connection refused")
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get(
+                "/xrpc/science.alt.dataset.getIndexSkeleton",
+                params={"index": "at://did:plc:provider1/science.alt.dataset.index/3abc"},
+            )
+            assert resp.status_code == 502
+
+
+@pytest.mark.asyncio
+@patch(f"{_QUERIES}.query_get_index_provider", new_callable=AsyncMock)
+async def test_get_index_skeleton_invalid_response(mock_get_provider):
+    """Upstream returns JSON without 'items' array."""
+    app, pool = _make_app()
+    mock_get_provider.return_value = _index_provider_row()
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"bad": "data"}
+
+    with patch("atdata_app.xrpc.queries.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_resp
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get(
+                "/xrpc/science.alt.dataset.getIndexSkeleton",
+                params={"index": "at://did:plc:provider1/science.alt.dataset.index/3abc"},
+            )
+            assert resp.status_code == 502
+
+
+# ---------------------------------------------------------------------------
+# getIndex (hydrated)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch(f"{_QUERIES}.query_get_entries", new_callable=AsyncMock)
+@patch(f"{_QUERIES}.query_get_index_provider", new_callable=AsyncMock)
+async def test_get_index_hydrated(mock_get_provider, mock_get_entries):
+    app, pool = _make_app()
+    mock_get_provider.return_value = _index_provider_row()
+    mock_get_entries.return_value = [_entry_row("did:plc:a", "3xyz")]
+
+    skeleton_response = {
+        "items": [
+            {"uri": "at://did:plc:a/science.alt.dataset.entry/3xyz"},
+        ],
+        "cursor": "next456",
+    }
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = skeleton_response
+
+    with patch("atdata_app.xrpc.queries.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_resp
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get(
+                "/xrpc/science.alt.dataset.getIndex",
+                params={"index": "at://did:plc:provider1/science.alt.dataset.index/3abc"},
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert len(data["items"]) == 1
+            assert data["items"][0]["name"] == "test-dataset"
+            assert data["cursor"] == "next456"
+
+
+@pytest.mark.asyncio
+@patch(f"{_QUERIES}.query_get_entries", new_callable=AsyncMock)
+@patch(f"{_QUERIES}.query_get_index_provider", new_callable=AsyncMock)
+async def test_get_index_omits_missing_entries(mock_get_provider, mock_get_entries):
+    """Entries not in the DB should be silently omitted."""
+    app, pool = _make_app()
+    mock_get_provider.return_value = _index_provider_row()
+    # Return only one of two requested entries
+    mock_get_entries.return_value = [_entry_row("did:plc:a", "3xyz")]
+
+    skeleton_response = {
+        "items": [
+            {"uri": "at://did:plc:a/science.alt.dataset.entry/3xyz"},
+            {"uri": "at://did:plc:b/science.alt.dataset.entry/3deleted"},
+        ],
+    }
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = skeleton_response
+
+    with patch("atdata_app.xrpc.queries.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_resp
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get(
+                "/xrpc/science.alt.dataset.getIndex",
+                params={"index": "at://did:plc:provider1/science.alt.dataset.index/3abc"},
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert len(data["items"]) == 1
+
+
+@pytest.mark.asyncio
+@patch(f"{_QUERIES}.query_get_index_provider", new_callable=AsyncMock)
+async def test_get_index_not_found(mock_get_provider):
+    app, pool = _make_app()
+    mock_get_provider.return_value = None
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/xrpc/science.alt.dataset.getIndex",
+            params={"index": "at://did:plc:missing/science.alt.dataset.index/3abc"},
+        )
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# listIndexes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch(f"{_QUERIES}.query_list_index_providers", new_callable=AsyncMock)
+async def test_list_indexes(mock_list):
+    app, pool = _make_app()
+    mock_list.return_value = [_index_provider_row()]
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/xrpc/science.alt.dataset.listIndexes")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["indexes"]) == 1
+        assert data["indexes"][0]["name"] == "Genomics Index"
+        assert data["indexes"][0]["endpointUrl"] == "https://example.com/skeleton"
+
+
+@pytest.mark.asyncio
+@patch(f"{_QUERIES}.query_list_index_providers", new_callable=AsyncMock)
+async def test_list_indexes_empty(mock_list):
+    app, pool = _make_app()
+    mock_list.return_value = []
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/xrpc/science.alt.dataset.listIndexes")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["indexes"] == []
+        assert data["cursor"] is None
+
+
+@pytest.mark.asyncio
+@patch(f"{_QUERIES}.query_list_index_providers", new_callable=AsyncMock)
+async def test_list_indexes_with_repo_filter(mock_list):
+    app, pool = _make_app()
+    mock_list.return_value = []
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/xrpc/science.alt.dataset.listIndexes",
+            params={"repo": "did:plc:provider1"},
+        )
+        assert resp.status_code == 200
+        mock_list.assert_called_once_with(pool, "did:plc:provider1", 50, None, None, None)
+
+
+# ---------------------------------------------------------------------------
+# publishIndex
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("atdata_app.xrpc.procedures.verify_service_auth", new_callable=AsyncMock)
+@patch("atdata_app.xrpc.procedures._resolve_pds", new_callable=AsyncMock)
+@patch("atdata_app.xrpc.procedures._proxy_create_record", new_callable=AsyncMock)
+async def test_publish_index(mock_proxy, mock_pds, mock_auth):
+    app, pool = _make_app()
+
+    mock_auth.return_value = MagicMock(iss="did:plc:publisher1")
+    mock_pds.return_value = "https://pds.example.com"
+    mock_proxy.return_value = {
+        "uri": "at://did:plc:publisher1/science.alt.dataset.index/3abc",
+        "cid": "bafynew",
+    }
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/xrpc/science.alt.dataset.publishIndex",
+            json={
+                "record": {
+                    "name": "Genomics Index",
+                    "endpointUrl": "https://example.com/skeleton",
+                    "createdAt": "2025-01-01T00:00:00Z",
+                },
+            },
+            headers={
+                "Authorization": "Bearer test-token",
+                "X-PDS-Auth": "pds-token",
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["uri"] == "at://did:plc:publisher1/science.alt.dataset.index/3abc"
+        assert data["cid"] == "bafynew"
+
+
+@pytest.mark.asyncio
+@patch("atdata_app.xrpc.procedures.verify_service_auth", new_callable=AsyncMock)
+async def test_publish_index_missing_field(mock_auth):
+    app, pool = _make_app()
+    mock_auth.return_value = MagicMock(iss="did:plc:publisher1")
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/xrpc/science.alt.dataset.publishIndex",
+            json={
+                "record": {
+                    "name": "Test",
+                    "createdAt": "2025-01-01T00:00:00Z",
+                    # missing endpointUrl
+                },
+            },
+            headers={
+                "Authorization": "Bearer test-token",
+                "X-PDS-Auth": "pds-token",
+            },
+        )
+        assert resp.status_code == 400
+        assert "endpointUrl" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+@patch("atdata_app.xrpc.procedures.verify_service_auth", new_callable=AsyncMock)
+async def test_publish_index_http_url_rejected(mock_auth):
+    app, pool = _make_app()
+    mock_auth.return_value = MagicMock(iss="did:plc:publisher1")
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/xrpc/science.alt.dataset.publishIndex",
+            json={
+                "record": {
+                    "name": "Bad Index",
+                    "endpointUrl": "http://insecure.example.com/skeleton",
+                    "createdAt": "2025-01-01T00:00:00Z",
+                },
+            },
+            headers={
+                "Authorization": "Bearer test-token",
+                "X-PDS-Auth": "pds-token",
+            },
+        )
+        assert resp.status_code == 400
+        assert "HTTPS" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+@patch("atdata_app.xrpc.procedures.verify_service_auth", new_callable=AsyncMock)
+async def test_publish_index_invalid_type(mock_auth):
+    app, pool = _make_app()
+    mock_auth.return_value = MagicMock(iss="did:plc:publisher1")
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/xrpc/science.alt.dataset.publishIndex",
+            json={
+                "record": {
+                    "$type": "science.alt.dataset.entry",
+                    "name": "Wrong Type",
+                    "endpointUrl": "https://example.com/skeleton",
+                    "createdAt": "2025-01-01T00:00:00Z",
+                },
+            },
+            headers={
+                "Authorization": "Bearer test-token",
+                "X-PDS-Auth": "pds-token",
+            },
+        )
+        assert resp.status_code == 400
+        assert "Invalid $type" in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Ingestion: index provider records
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch(f"{_DB}.upsert_index_provider", new_callable=AsyncMock)
+async def test_process_commit_index_provider(mock_upsert):
+    pool = AsyncMock()
+    event = {
+        "did": "did:plc:provider1",
+        "time_us": 1725911162329308,
+        "kind": "commit",
+        "commit": {
+            "rev": "rev1",
+            "operation": "create",
+            "collection": "science.alt.dataset.index",
+            "rkey": "3abc",
+            "record": {
+                "$type": "science.alt.dataset.index",
+                "name": "Genomics Index",
+                "endpointUrl": "https://example.com/skeleton",
+                "createdAt": "2025-01-01T00:00:00Z",
+            },
+            "cid": "bafyindex",
+        },
+    }
+    await process_commit(pool, event)
+    mock_upsert.assert_called_once_with(
+        pool, "did:plc:provider1", "3abc", "bafyindex", event["commit"]["record"]
+    )
+
+
+@pytest.mark.asyncio
+@patch(f"{_DB}.delete_record", new_callable=AsyncMock)
+async def test_process_commit_delete_index_provider(mock_delete):
+    pool = AsyncMock()
+    event = {
+        "did": "did:plc:provider1",
+        "time_us": 1725911162329308,
+        "kind": "commit",
+        "commit": {
+            "rev": "rev1",
+            "operation": "delete",
+            "collection": "science.alt.dataset.index",
+            "rkey": "3abc",
+        },
+    }
+    await process_commit(pool, event)
+    mock_delete.assert_called_once_with(pool, "index_providers", "did:plc:provider1", "3abc")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -162,6 +162,7 @@ class TestSchemaValidation:
             "entries",
             "labels",
             "lenses",
+            "index_providers",
             "cursor_state",
             "analytics_events",
             "analytics_counters",
@@ -196,6 +197,8 @@ class TestSchemaValidation:
             "idx_lenses_did",
             "idx_analytics_events_type_created",
             "idx_analytics_events_target",
+            "idx_index_providers_did",
+            "idx_index_providers_indexed_at",
         }
         async with db_pool.acquire() as conn:
             rows = await conn.fetch(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,6 +10,7 @@ from atdata_app.models import (
     make_at_uri,
     parse_at_uri,
     row_to_entry,
+    row_to_index_provider,
     row_to_label,
     row_to_lens,
     row_to_schema,
@@ -193,6 +194,7 @@ _LABEL_ROW = {
 def test_row_to_label():
     d = row_to_label(_LABEL_ROW)
     assert d["uri"] == "at://did:plc:abc/science.alt.dataset.label/3lbl"
+    assert d["did"] == "did:plc:abc"
     assert d["datasetUri"] == _LABEL_ROW["dataset_uri"]
     assert d["version"] == "1.0.0"
     assert d["description"] == "First version"
@@ -227,6 +229,7 @@ _LENS_ROW = {
 def test_row_to_lens():
     d = row_to_lens(_LENS_ROW)
     assert d["uri"] == "at://did:plc:abc/science.alt.dataset.lens/3lens"
+    assert d["did"] == "did:plc:abc"
     assert d["sourceSchema"] == _LENS_ROW["source_schema"]
     assert d["getterCode"] == _LENS_ROW["getter_code"]
     assert d["description"] == "Transforms A to B"
@@ -249,3 +252,33 @@ def test_row_to_lens_json_string_code():
     d = row_to_lens(row)
     assert d["getterCode"] == {"repo": "x"}
     assert d["putterCode"] == {"repo": "y"}
+
+
+# ---------------------------------------------------------------------------
+# row_to_index_provider
+# ---------------------------------------------------------------------------
+
+_INDEX_PROVIDER_ROW = {
+    "did": "did:plc:provider1",
+    "rkey": "3idx",
+    "cid": "bafyindex",
+    "name": "Genomics Index",
+    "description": "Curated genomics datasets",
+    "endpoint_url": "https://example.com/skeleton",
+    "created_at": "2025-01-01T00:00:00Z",
+}
+
+
+def test_row_to_index_provider():
+    d = row_to_index_provider(_INDEX_PROVIDER_ROW)
+    assert d["uri"] == "at://did:plc:provider1/science.alt.dataset.index/3idx"
+    assert d["did"] == "did:plc:provider1"
+    assert d["name"] == "Genomics Index"
+    assert d["endpointUrl"] == "https://example.com/skeleton"
+    assert d["description"] == "Curated genomics datasets"
+
+
+def test_row_to_index_provider_omits_null_description():
+    row = {**_INDEX_PROVIDER_ROW, "description": None}
+    d = row_to_index_provider(row)
+    assert "description" not in d


### PR DESCRIPTION
## Summary

- Add `index_providers` table and full CRUD support for `science.alt.dataset.index` records (schema, upsert, ingestion, delete)
- Add `getIndexSkeleton` XRPC query that fetches URI stubs from an upstream index provider endpoint, following Bluesky's `getFeedSkeleton` pattern
- Add `getIndex` XRPC query that fetches the skeleton then hydrates entries from the local DB, preserving skeleton ordering and silently omitting missing entries
- Add `listIndexes` paginated query and `publishIndex` procedure with HTTPS URL validation
- Fix `row_to_label` and `row_to_lens` missing `did` field (consistency bug across all serializers)
- Add `index_providers` to `query_active_publishers` UNION, fix import ordering, add missing tests

## Test plan

- [x] 18 new tests in `test_index.py` covering skeleton fetch, hydration, list, publish, and ingestion
- [x] 2 new `row_to_index_provider` serializer tests in `test_models.py`
- [x] Integration test expectations updated for `index_providers` table and indexes
- [x] All 163 tests pass, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)