### PR TITLE
feat: add subscribeChanges WebSocket endpoint for real-time change streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - DID document service entry updated from `#atproto_appview` / `AtprotoAppView` to `#atdata_appview` / `AtdataAppView`
 
 ### Added
+- Add real-time change stream subscribeChanges endpoint (#50)
 
 - Dual-hostname DID document support — serve different `did:web` documents for `api.atdata.app` (appview identity) and `atdata.app` (atproto account identity) based on the `Host` header ([#19](https://github.com/forecast-bio/atdata-app/issues/19))
 - Host-based route gating middleware — frontend HTML routes are only served on the frontend hostname; the API subdomain serves only XRPC, health, and DID endpoints

--- a/src/atdata_app/changestream.py
+++ b/src/atdata_app/changestream.py
@@ -1,0 +1,152 @@
+"""In-memory broadcast channel for real-time change events.
+
+Provides a pub/sub mechanism that the ingestion processor publishes to
+and WebSocket subscribers consume from. Maintains a bounded buffer of
+recent events for cursor-based replay.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BUFFER_SIZE = 1000
+DEFAULT_SUBSCRIBER_QUEUE_SIZE = 256
+
+
+@dataclass
+class ChangeEvent:
+    """A single change event in the stream."""
+
+    seq: int
+    type: str  # "create", "update", or "delete"
+    collection: str
+    did: str
+    rkey: str
+    timestamp: str
+    record: dict[str, Any] | None = None
+    cid: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {
+            "seq": self.seq,
+            "type": self.type,
+            "collection": self.collection,
+            "did": self.did,
+            "rkey": self.rkey,
+            "timestamp": self.timestamp,
+        }
+        if self.record is not None:
+            d["record"] = self.record
+        if self.cid is not None:
+            d["cid"] = self.cid
+        return d
+
+
+@dataclass
+class ChangeStream:
+    """Broadcast channel with bounded replay buffer.
+
+    Thread-safe for asyncio: all mutations happen in the event loop.
+    """
+
+    buffer_size: int = DEFAULT_BUFFER_SIZE
+    subscriber_queue_size: int = DEFAULT_SUBSCRIBER_QUEUE_SIZE
+    _seq: int = field(default=0, init=False)
+    _buffer: deque[ChangeEvent] = field(init=False)
+    _subscribers: dict[int, asyncio.Queue[ChangeEvent]] = field(
+        default_factory=dict, init=False
+    )
+    _next_sub_id: int = field(default=0, init=False)
+
+    def __post_init__(self) -> None:
+        self._buffer = deque(maxlen=self.buffer_size)
+
+    def publish(self, event: ChangeEvent) -> None:
+        """Publish an event to all subscribers and the replay buffer.
+
+        Non-blocking. If a subscriber's queue is full, the event is dropped
+        for that subscriber (backpressure via disconnect is handled by the
+        WebSocket handler).
+        """
+        self._seq += 1
+        event.seq = self._seq
+        self._buffer.append(event)
+
+        for sub_id, queue in list(self._subscribers.items()):
+            try:
+                queue.put_nowait(event)
+            except asyncio.QueueFull:
+                logger.warning(
+                    "Subscriber %d queue full, dropping event seq=%d",
+                    sub_id,
+                    event.seq,
+                )
+
+    def subscribe(self) -> tuple[int, asyncio.Queue[ChangeEvent]]:
+        """Create a new subscriber. Returns (subscriber_id, queue)."""
+        sub_id = self._next_sub_id
+        self._next_sub_id += 1
+        queue: asyncio.Queue[ChangeEvent] = asyncio.Queue(
+            maxsize=self.subscriber_queue_size
+        )
+        self._subscribers[sub_id] = queue
+        logger.debug("Subscriber %d connected (total: %d)", sub_id, len(self._subscribers))
+        return sub_id, queue
+
+    def unsubscribe(self, sub_id: int) -> None:
+        """Remove a subscriber."""
+        self._subscribers.pop(sub_id, None)
+        logger.debug("Subscriber %d disconnected (total: %d)", sub_id, len(self._subscribers))
+
+    def replay_from(self, cursor: int) -> list[ChangeEvent]:
+        """Return buffered events with seq > cursor.
+
+        Returns an empty list if the cursor is outside the buffer window.
+        """
+        if not self._buffer:
+            return []
+
+        oldest_seq = self._buffer[0].seq
+        if cursor < oldest_seq - 1:
+            # Cursor is too old — events between cursor and buffer start were lost
+            return []
+
+        return [ev for ev in self._buffer if ev.seq > cursor]
+
+    @property
+    def current_seq(self) -> int:
+        return self._seq
+
+    @property
+    def subscriber_count(self) -> int:
+        return len(self._subscribers)
+
+
+def make_change_event(
+    *,
+    event_type: str,
+    collection: str,
+    did: str,
+    rkey: str,
+    record: dict[str, Any] | None = None,
+    cid: str | None = None,
+) -> ChangeEvent:
+    """Factory for creating change events with current timestamp."""
+    from datetime import datetime, timezone
+
+    return ChangeEvent(
+        seq=0,  # Assigned by ChangeStream.publish()
+        type=event_type,
+        collection=collection,
+        did=did,
+        rkey=rkey,
+        timestamp=datetime.now(timezone.utc).isoformat(),
+        record=record,
+        cid=cid,
+    )

--- a/src/atdata_app/ingestion/jetstream.py
+++ b/src/atdata_app/ingestion/jetstream.py
@@ -52,7 +52,9 @@ async def jetstream_consumer(app: FastAPI) -> None:
                     if event.get("kind") != "commit":
                         continue
 
-                    await process_commit(pool, event)
+                    await process_commit(
+                        pool, event, getattr(app.state, "change_stream", None)
+                    )
 
                     last_time_us = event.get("time_us")
                     msg_count += 1

--- a/src/atdata_app/ingestion/processor.py
+++ b/src/atdata_app/ingestion/processor.py
@@ -8,11 +8,16 @@ from typing import Any
 import asyncpg
 
 from atdata_app import database as db
+from atdata_app.changestream import ChangeStream, make_change_event
 
 logger = logging.getLogger(__name__)
 
 
-async def process_commit(pool: asyncpg.Pool, event: dict[str, Any]) -> None:
+async def process_commit(
+    pool: asyncpg.Pool,
+    event: dict[str, Any],
+    change_stream: ChangeStream | None = None,
+) -> None:
     """Process a Jetstream commit event.
 
     Expected event format::
@@ -44,6 +49,15 @@ async def process_commit(pool: asyncpg.Pool, event: dict[str, Any]) -> None:
     if operation == "delete":
         await db.delete_record(pool, table, did, rkey)
         logger.debug("Deleted %s %s/%s", collection, did, rkey)
+        if change_stream is not None:
+            change_stream.publish(
+                make_change_event(
+                    event_type="delete",
+                    collection=collection,
+                    did=did,
+                    rkey=rkey,
+                )
+            )
     elif operation in ("create", "update"):
         record = commit["record"]
         cid = commit.get("cid")
@@ -57,5 +71,16 @@ async def process_commit(pool: asyncpg.Pool, event: dict[str, Any]) -> None:
             elif table == "lenses":
                 await db.upsert_lens(pool, did, rkey, cid, record)
             logger.debug("Upserted %s %s/%s", collection, did, rkey)
+            if change_stream is not None:
+                change_stream.publish(
+                    make_change_event(
+                        event_type=operation,
+                        collection=collection,
+                        did=did,
+                        rkey=rkey,
+                        record=record,
+                        cid=cid,
+                    )
+                )
         except Exception:
             logger.exception("Failed to upsert %s %s/%s", collection, did, rkey)

--- a/src/atdata_app/main.py
+++ b/src/atdata_app/main.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI, Request, Response
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 
+from atdata_app.changestream import ChangeStream
 from atdata_app.config import AppConfig
 from atdata_app.database import create_pool, run_migrations
 from atdata_app.frontend import router as frontend_router
@@ -29,6 +30,9 @@ _SHARED_PATH_PREFIXES = ("/xrpc/", "/.well-known/", "/health")
 async def lifespan(app: FastAPI):
     config: AppConfig = app.state.config
     logger.info("Starting atdata-app (DID: %s)", config.service_did)
+
+    # Change stream (must be created before background tasks)
+    app.state.change_stream = ChangeStream()
 
     # Database
     pool = await create_pool(config.database_url)

--- a/src/atdata_app/xrpc/router.py
+++ b/src/atdata_app/xrpc/router.py
@@ -1,10 +1,12 @@
-"""Combined XRPC router mounting all query and procedure endpoints."""
+"""Combined XRPC router mounting all query, procedure, and subscription endpoints."""
 
 from fastapi import APIRouter
 
 from atdata_app.xrpc.procedures import router as procedures_router
 from atdata_app.xrpc.queries import router as queries_router
+from atdata_app.xrpc.subscriptions import router as subscriptions_router
 
 router = APIRouter(prefix="/xrpc")
 router.include_router(queries_router)
 router.include_router(procedures_router)
+router.include_router(subscriptions_router)

--- a/src/atdata_app/xrpc/subscriptions.py
+++ b/src/atdata_app/xrpc/subscriptions.py
@@ -1,0 +1,53 @@
+"""WebSocket subscription endpoints for real-time change streaming."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+from atdata_app.changestream import ChangeStream
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.websocket("/science.alt.dataset.subscribeChanges")
+async def subscribe_changes(websocket: WebSocket) -> None:
+    """Stream real-time change events over WebSocket.
+
+    Query parameters:
+        cursor: Optional sequence number to replay from.
+    """
+    change_stream: ChangeStream = websocket.app.state.change_stream
+
+    await websocket.accept()
+
+    cursor_param = websocket.query_params.get("cursor")
+    sub_id, queue = change_stream.subscribe()
+
+    try:
+        # Replay buffered events if cursor provided
+        if cursor_param is not None:
+            try:
+                cursor = int(cursor_param)
+            except (ValueError, TypeError):
+                await websocket.close(code=1008, reason="Invalid cursor value")
+                return
+            missed = change_stream.replay_from(cursor)
+            for event in missed:
+                await websocket.send_text(json.dumps(event.to_dict()))
+
+        # Stream live events
+        while True:
+            event = await queue.get()
+            await websocket.send_text(json.dumps(event.to_dict()))
+
+    except WebSocketDisconnect:
+        logger.debug("Subscriber %d disconnected", sub_id)
+    except Exception:
+        logger.exception("Error in subscriber %d", sub_id)
+    finally:
+        change_stream.unsubscribe(sub_id)

--- a/tests/test_changestream.py
+++ b/tests/test_changestream.py
@@ -1,0 +1,440 @@
+"""Tests for the change stream event bus and WebSocket subscription endpoint."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+from atdata_app.changestream import ChangeEvent, ChangeStream, make_change_event
+from atdata_app.ingestion.processor import process_commit
+from atdata_app.xrpc.subscriptions import router as subscriptions_router
+
+
+# ---------------------------------------------------------------------------
+# ChangeStream unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestChangeStream:
+    def test_publish_assigns_monotonic_seq(self):
+        cs = ChangeStream()
+        ev1 = make_change_event(
+            event_type="create",
+            collection="science.alt.dataset.entry",
+            did="did:plc:test",
+            rkey="abc",
+        )
+        ev2 = make_change_event(
+            event_type="update",
+            collection="science.alt.dataset.entry",
+            did="did:plc:test",
+            rkey="def",
+        )
+        cs.publish(ev1)
+        cs.publish(ev2)
+        assert ev1.seq == 1
+        assert ev2.seq == 2
+        assert cs.current_seq == 2
+
+    def test_publish_delivers_to_subscribers(self):
+        cs = ChangeStream()
+        sub_id, queue = cs.subscribe()
+
+        ev = make_change_event(
+            event_type="create",
+            collection="science.alt.dataset.entry",
+            did="did:plc:test",
+            rkey="abc",
+        )
+        cs.publish(ev)
+
+        assert not queue.empty()
+        received = queue.get_nowait()
+        assert received.seq == 1
+        assert received.did == "did:plc:test"
+
+    def test_multiple_subscribers_receive_events(self):
+        cs = ChangeStream()
+        _, q1 = cs.subscribe()
+        _, q2 = cs.subscribe()
+
+        ev = make_change_event(
+            event_type="create",
+            collection="science.alt.dataset.entry",
+            did="did:plc:test",
+            rkey="abc",
+        )
+        cs.publish(ev)
+
+        assert not q1.empty()
+        assert not q2.empty()
+        assert q1.get_nowait().seq == 1
+        assert q2.get_nowait().seq == 1
+
+    def test_unsubscribe_removes_subscriber(self):
+        cs = ChangeStream()
+        sub_id, queue = cs.subscribe()
+        assert cs.subscriber_count == 1
+
+        cs.unsubscribe(sub_id)
+        assert cs.subscriber_count == 0
+
+        # Publishing after unsubscribe should not deliver
+        ev = make_change_event(
+            event_type="create",
+            collection="science.alt.dataset.entry",
+            did="did:plc:test",
+            rkey="abc",
+        )
+        cs.publish(ev)
+        assert queue.empty()
+
+    def test_full_queue_drops_event(self):
+        cs = ChangeStream(subscriber_queue_size=1)
+        _, queue = cs.subscribe()
+
+        ev1 = make_change_event(
+            event_type="create",
+            collection="science.alt.dataset.entry",
+            did="did:plc:test",
+            rkey="a",
+        )
+        ev2 = make_change_event(
+            event_type="create",
+            collection="science.alt.dataset.entry",
+            did="did:plc:test",
+            rkey="b",
+        )
+        cs.publish(ev1)
+        cs.publish(ev2)  # Should be dropped (queue full)
+
+        assert queue.qsize() == 1
+        assert queue.get_nowait().rkey == "a"
+
+    def test_replay_from_cursor(self):
+        cs = ChangeStream(buffer_size=10)
+        for i in range(5):
+            ev = make_change_event(
+                event_type="create",
+                collection="science.alt.dataset.entry",
+                did="did:plc:test",
+                rkey=str(i),
+            )
+            cs.publish(ev)
+
+        # Replay from seq 3 — should get events 4 and 5
+        replayed = cs.replay_from(3)
+        assert len(replayed) == 2
+        assert replayed[0].seq == 4
+        assert replayed[1].seq == 5
+
+    def test_replay_from_zero_returns_all(self):
+        cs = ChangeStream(buffer_size=10)
+        for i in range(3):
+            ev = make_change_event(
+                event_type="create",
+                collection="science.alt.dataset.entry",
+                did="did:plc:test",
+                rkey=str(i),
+            )
+            cs.publish(ev)
+
+        replayed = cs.replay_from(0)
+        assert len(replayed) == 3
+
+    def test_replay_cursor_too_old(self):
+        cs = ChangeStream(buffer_size=3)
+        for i in range(5):
+            ev = make_change_event(
+                event_type="create",
+                collection="science.alt.dataset.entry",
+                did="did:plc:test",
+                rkey=str(i),
+            )
+            cs.publish(ev)
+
+        # Buffer only holds seq 3, 4, 5 — cursor 1 is too old
+        replayed = cs.replay_from(1)
+        assert len(replayed) == 0
+
+    def test_replay_empty_buffer(self):
+        cs = ChangeStream()
+        assert cs.replay_from(0) == []
+
+    def test_bounded_buffer(self):
+        cs = ChangeStream(buffer_size=3)
+        for i in range(10):
+            ev = make_change_event(
+                event_type="create",
+                collection="science.alt.dataset.entry",
+                did="did:plc:test",
+                rkey=str(i),
+            )
+            cs.publish(ev)
+
+        assert len(cs._buffer) == 3
+        assert cs._buffer[0].seq == 8
+        assert cs._buffer[-1].seq == 10
+
+
+class TestChangeEvent:
+    def test_to_dict_create(self):
+        ev = ChangeEvent(
+            seq=1,
+            type="create",
+            collection="science.alt.dataset.entry",
+            did="did:plc:test",
+            rkey="abc",
+            timestamp="2026-01-01T00:00:00Z",
+            record={"name": "test"},
+            cid="bafytest",
+        )
+        d = ev.to_dict()
+        assert d["seq"] == 1
+        assert d["type"] == "create"
+        assert d["record"] == {"name": "test"}
+        assert d["cid"] == "bafytest"
+
+    def test_to_dict_delete_omits_record_and_cid(self):
+        ev = ChangeEvent(
+            seq=2,
+            type="delete",
+            collection="science.alt.dataset.entry",
+            did="did:plc:test",
+            rkey="abc",
+            timestamp="2026-01-01T00:00:00Z",
+        )
+        d = ev.to_dict()
+        assert "record" not in d
+        assert "cid" not in d
+
+
+class TestMakeChangeEvent:
+    def test_creates_event_with_timestamp(self):
+        ev = make_change_event(
+            event_type="create",
+            collection="science.alt.dataset.entry",
+            did="did:plc:test",
+            rkey="abc",
+            record={"name": "test"},
+            cid="bafytest",
+        )
+        assert ev.seq == 0  # Not yet assigned
+        assert ev.type == "create"
+        assert ev.timestamp  # Should have a timestamp
+
+
+# ---------------------------------------------------------------------------
+# Processor integration tests
+# ---------------------------------------------------------------------------
+
+_DB = "atdata_app.database"
+
+
+def _make_event(
+    did: str = "did:plc:test123",
+    collection: str = "science.alt.dataset.entry",
+    operation: str = "create",
+    rkey: str = "3xyz",
+    record: dict | None = None,
+    cid: str = "bafytest",
+) -> dict:
+    commit: dict = {
+        "rev": "rev1",
+        "operation": operation,
+        "collection": collection,
+        "rkey": rkey,
+    }
+    if operation != "delete":
+        commit["record"] = record or {
+            "$type": collection,
+            "name": "test-dataset",
+            "schemaRef": "at://did:plc:test/science.alt.dataset.schema/test@1.0.0",
+            "storage": {"$type": "science.alt.dataset.storageHttp", "shards": []},
+            "createdAt": "2025-01-01T00:00:00Z",
+        }
+        commit["cid"] = cid
+
+    return {
+        "did": did,
+        "time_us": 1725911162329308,
+        "kind": "commit",
+        "commit": commit,
+    }
+
+
+@pytest.mark.asyncio
+@patch(f"{_DB}.upsert_entry", new_callable=AsyncMock)
+async def test_processor_publishes_create_event(mock_upsert):
+    pool = AsyncMock()
+    cs = ChangeStream()
+    _, queue = cs.subscribe()
+
+    event = _make_event(operation="create")
+    await process_commit(pool, event, change_stream=cs)
+
+    assert not queue.empty()
+    change_event = queue.get_nowait()
+    assert change_event.type == "create"
+    assert change_event.collection == "science.alt.dataset.entry"
+    assert change_event.did == "did:plc:test123"
+    assert change_event.rkey == "3xyz"
+    assert change_event.record is not None
+    assert change_event.cid == "bafytest"
+
+
+@pytest.mark.asyncio
+@patch(f"{_DB}.delete_record", new_callable=AsyncMock)
+async def test_processor_publishes_delete_event(mock_delete):
+    pool = AsyncMock()
+    cs = ChangeStream()
+    _, queue = cs.subscribe()
+
+    event = _make_event(operation="delete")
+    await process_commit(pool, event, change_stream=cs)
+
+    assert not queue.empty()
+    change_event = queue.get_nowait()
+    assert change_event.type == "delete"
+    assert change_event.collection == "science.alt.dataset.entry"
+    assert change_event.record is None
+    assert change_event.cid is None
+
+
+@pytest.mark.asyncio
+@patch(f"{_DB}.upsert_entry", new_callable=AsyncMock)
+async def test_processor_no_event_on_upsert_failure(mock_upsert):
+    mock_upsert.side_effect = Exception("db error")
+    pool = AsyncMock()
+    cs = ChangeStream()
+    _, queue = cs.subscribe()
+
+    event = _make_event(operation="create")
+    await process_commit(pool, event, change_stream=cs)
+
+    assert queue.empty()
+
+
+@pytest.mark.asyncio
+@patch(f"{_DB}.upsert_entry", new_callable=AsyncMock)
+async def test_processor_works_without_change_stream(mock_upsert):
+    """Backward compat: process_commit works when change_stream is None."""
+    pool = AsyncMock()
+    event = _make_event(operation="create")
+    await process_commit(pool, event)
+    mock_upsert.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# WebSocket endpoint tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app_with_changestream():
+    """Minimal app with just the subscriptions router — no DB lifespan."""
+    app = FastAPI()
+    app.state.change_stream = ChangeStream()
+    app.include_router(subscriptions_router, prefix="/xrpc")
+    return app
+
+
+def test_websocket_subscribe_and_receive(app_with_changestream):
+    app = app_with_changestream
+    cs: ChangeStream = app.state.change_stream
+
+    with TestClient(app) as client:
+        with client.websocket_connect(
+            "/xrpc/science.alt.dataset.subscribeChanges"
+        ) as ws:
+            # Publish an event from another "thread"
+            cs.publish(
+                make_change_event(
+                    event_type="create",
+                    collection="science.alt.dataset.entry",
+                    did="did:plc:test",
+                    rkey="abc",
+                    record={"name": "test"},
+                    cid="bafytest",
+                )
+            )
+
+            data = ws.receive_json()
+            assert data["seq"] == 1
+            assert data["type"] == "create"
+            assert data["collection"] == "science.alt.dataset.entry"
+            assert data["did"] == "did:plc:test"
+            assert data["record"] == {"name": "test"}
+
+
+def test_websocket_cursor_replay(app_with_changestream):
+    app = app_with_changestream
+    cs: ChangeStream = app.state.change_stream
+
+    # Pre-populate buffer
+    for i in range(5):
+        cs.publish(
+            make_change_event(
+                event_type="create",
+                collection="science.alt.dataset.entry",
+                did="did:plc:test",
+                rkey=str(i),
+            )
+        )
+
+    with TestClient(app) as client:
+        with client.websocket_connect(
+            "/xrpc/science.alt.dataset.subscribeChanges?cursor=3"
+        ) as ws:
+            # Should replay events 4 and 5
+            msg1 = ws.receive_json()
+            assert msg1["seq"] == 4
+
+            msg2 = ws.receive_json()
+            assert msg2["seq"] == 5
+
+
+def test_websocket_disconnect_cleanup(app_with_changestream):
+    app = app_with_changestream
+    cs: ChangeStream = app.state.change_stream
+
+    with TestClient(app) as client:
+        with client.websocket_connect(
+            "/xrpc/science.alt.dataset.subscribeChanges"
+        ):
+            assert cs.subscriber_count == 1
+
+    # After disconnect, subscriber should be cleaned up
+    assert cs.subscriber_count == 0
+
+
+def test_websocket_multiple_subscribers(app_with_changestream):
+    app = app_with_changestream
+    cs: ChangeStream = app.state.change_stream
+
+    with TestClient(app) as client:
+        with client.websocket_connect(
+            "/xrpc/science.alt.dataset.subscribeChanges"
+        ) as ws1:
+            with client.websocket_connect(
+                "/xrpc/science.alt.dataset.subscribeChanges"
+            ) as ws2:
+                assert cs.subscriber_count == 2
+
+                cs.publish(
+                    make_change_event(
+                        event_type="create",
+                        collection="science.alt.dataset.entry",
+                        did="did:plc:test",
+                        rkey="abc",
+                    )
+                )
+
+                d1 = ws1.receive_json()
+                d2 = ws2.receive_json()
+                assert d1["seq"] == d2["seq"] == 1
+
+    assert cs.subscriber_count == 0


### PR DESCRIPTION
## Summary

- Adds an in-memory broadcast event bus (`changestream.py`) with bounded replay buffer and per-subscriber queues
- Hooks into `ingestion/processor.py` to publish change events after successful upserts/deletes
- New WebSocket endpoint at `/xrpc/science.alt.dataset.subscribeChanges` with optional cursor-based replay
- 21 new tests covering the event bus, processor integration, WebSocket subscribe/replay/disconnect/concurrency

## Test plan

- [x] All 164 tests pass (`uv run pytest`)
- [x] Lint clean (`uv run ruff check src/ tests/`)
- [ ] Manual test: connect via WebSocket, publish a record, verify event arrives
- [ ] Verify cursor replay works with pre-populated buffer
- [ ] Verify slow subscribers get events dropped (not unbounded queue growth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)