### PR TITLE
feat: add array format types and ndarray v1.1.0 annotations

### DIFF
--- a/src/atdata_app/frontend/routes.py
+++ b/src/atdata_app/frontend/routes.py
@@ -105,6 +105,13 @@ async def dataset_detail(request: Request, did: str, rkey: str):
         if len(parts) == 3:
             schema_did, _, schema_rkey = parts
 
+    # Fetch the referenced schema for inline display of format/annotation info
+    schema_info = None
+    if schema_did and schema_rkey:
+        schema_row = await query_get_schema(pool, schema_did, schema_rkey)
+        if schema_row:
+            schema_info = row_to_schema(schema_row)
+
     # Fetch labels pointing to this dataset
     dataset_uri = entry["uri"]
     label_rows = await query_labels_for_dataset(pool, dataset_uri)
@@ -117,6 +124,7 @@ async def dataset_detail(request: Request, did: str, rkey: str):
             "entry": entry,
             "schema_did": schema_did,
             "schema_rkey": schema_rkey,
+            "schema_info": schema_info,
             "labels": labels,
         },
     )

--- a/src/atdata_app/frontend/templates/dataset.html
+++ b/src/atdata_app/frontend/templates/dataset.html
@@ -27,6 +27,20 @@
             <tr><th>License</th><td>{{ entry.license }}</td></tr>
             {% endif %}
             <tr><th>Schema</th><td><a href="/schema/{{ schema_did }}/{{ schema_rkey }}">{{ entry.schemaRef }}</a></td></tr>
+            {% if schema_info %}
+            {% if schema_info.arrayFormat is defined %}
+            <tr><th>Array Format</th><td>{{ schema_info.get("arrayFormatLabel", schema_info.arrayFormat) }}</td></tr>
+            {% endif %}
+            {% if schema_info.dtype is defined %}
+            <tr><th>Data Type</th><td><code>{{ schema_info.dtype }}</code></td></tr>
+            {% endif %}
+            {% if schema_info.shape is defined %}
+            <tr><th>Shape</th><td><code>{{ schema_info.shape | join(" × ") }}</code></td></tr>
+            {% endif %}
+            {% if schema_info.dimensionNames is defined %}
+            <tr><th>Dimensions</th><td>{{ schema_info.dimensionNames | join(", ") }}</td></tr>
+            {% endif %}
+            {% endif %}
             {% if entry.size %}
             <tr>
                 <th>Size</th>

--- a/src/atdata_app/frontend/templates/profile.html
+++ b/src/atdata_app/frontend/templates/profile.html
@@ -34,13 +34,14 @@
     <h2>Schemas</h2>
     {% if schemas %}
     <table>
-        <thead><tr><th>Name</th><th>Version</th><th>Type</th></tr></thead>
+        <thead><tr><th>Name</th><th>Version</th><th>Type</th><th>Format</th></tr></thead>
         <tbody>
             {% for s in schemas %}
             <tr>
                 <td><a href="/schema/{{ s.did }}/{{ s.rkey }}">{{ s.name }}</a></td>
                 <td>{{ s.version }}</td>
                 <td>{{ s.schemaType }}</td>
+                <td>{{ s.get("arrayFormatLabel", "") }}</td>
             </tr>
             {% endfor %}
         </tbody>

--- a/src/atdata_app/frontend/templates/schema.html
+++ b/src/atdata_app/frontend/templates/schema.html
@@ -16,6 +16,18 @@
         <tbody>
             <tr><th>AT-URI</th><td><code>{{ schema.uri }}</code></td></tr>
             <tr><th>Type</th><td>{{ schema.schemaType }}</td></tr>
+            {% if schema.arrayFormat is defined %}
+            <tr><th>Array Format</th><td>{{ schema.get("arrayFormatLabel", schema.arrayFormat) }}</td></tr>
+            {% endif %}
+            {% if schema.dtype is defined %}
+            <tr><th>Data Type</th><td><code>{{ schema.dtype }}</code></td></tr>
+            {% endif %}
+            {% if schema.shape is defined %}
+            <tr><th>Shape</th><td><code>{{ schema.shape | join(" × ") }}</code></td></tr>
+            {% endif %}
+            {% if schema.dimensionNames is defined %}
+            <tr><th>Dimensions</th><td>{{ schema.dimensionNames | join(", ") }}</td></tr>
+            {% endif %}
             <tr><th>Version</th><td>{{ schema.version }}</td></tr>
             <tr><th>Created</th><td>{{ schema.createdAt }}</td></tr>
         </tbody>

--- a/src/atdata_app/frontend/templates/schemas.html
+++ b/src/atdata_app/frontend/templates/schemas.html
@@ -7,7 +7,7 @@
     {% if schemas %}
     <table>
         <thead>
-            <tr><th>Name</th><th>Version</th><th>Type</th><th>Description</th><th>Publisher</th></tr>
+            <tr><th>Name</th><th>Version</th><th>Type</th><th>Format</th><th>Description</th><th>Publisher</th></tr>
         </thead>
         <tbody>
             {% for s in schemas %}
@@ -15,6 +15,7 @@
                 <td><a href="/schema/{{ s.did }}/{{ s.rkey }}">{{ s.name }}</a></td>
                 <td>{{ s.version }}</td>
                 <td>{{ s.schemaType }}</td>
+                <td>{{ s.get("arrayFormatLabel", "") }}</td>
                 <td>{{ s.get("description", "") }}</td>
                 <td><a href="/profile/{{ s.did }}">{{ s.did[:20] }}…</a></td>
             </tr>

--- a/src/atdata_app/mcp_server.py
+++ b/src/atdata_app/mcp_server.py
@@ -57,7 +57,10 @@ mcp_server = FastMCP(
         "ATProto AppView for the science.alt.dataset namespace. "
         "Use these tools to discover and query scientific datasets, "
         "schemas, and lenses (bidirectional schema transforms) published "
-        "on the AT Protocol network."
+        "on the AT Protocol network. "
+        "Schemas may specify an arrayFormat (numpyBytes, parquetBytes, "
+        "sparseBytes, structuredBytes, arrowTensor, safetensors) and "
+        "ndarray annotations (dtype, shape, dimensionNames)."
     ),
     lifespan=server_lifespan,
 )
@@ -127,7 +130,8 @@ async def get_schema(ctx: Ctx, uri: str) -> dict[str, Any]:
         uri: AT-URI of the schema (e.g. at://did:plc:abc/science.alt.dataset.schema/my.schema@1.0.0).
 
     Returns:
-        Full schema record including name, version, type, schema body, and description.
+        Full schema record including name, version, type, schema body, description,
+        and (when present) arrayFormat, dtype, shape, and dimensionNames.
     """
     sc = _get_ctx(ctx)
     did, _collection, rkey = parse_at_uri(uri)

--- a/src/atdata_app/models.py
+++ b/src/atdata_app/models.py
@@ -10,6 +10,32 @@ from pydantic import BaseModel
 
 
 # ---------------------------------------------------------------------------
+# Known array format tokens (atdata-lexicon#21)
+# ---------------------------------------------------------------------------
+
+KNOWN_ARRAY_FORMATS: set[str] = {
+    # Original formats
+    "numpyBytes",
+    "parquetBytes",
+    # New formats
+    "sparseBytes",
+    "structuredBytes",
+    "arrowTensor",
+    "safetensors",
+}
+
+#: Human-friendly display names for array format tokens.
+ARRAY_FORMAT_LABELS: dict[str, str] = {
+    "numpyBytes": "NumPy ndarray",
+    "parquetBytes": "Parquet",
+    "sparseBytes": "Sparse matrix (CSR/CSC/COO)",
+    "structuredBytes": "NumPy structured array",
+    "arrowTensor": "Arrow tensor IPC",
+    "safetensors": "Safetensors",
+}
+
+
+# ---------------------------------------------------------------------------
 # AT-URI parsing
 # ---------------------------------------------------------------------------
 
@@ -119,6 +145,19 @@ def row_to_schema(row) -> dict[str, Any]:
     }
     if row["description"]:
         d["description"] = row["description"]
+
+    # Surface array format and ndarray v1.1.0 annotation fields for display
+    array_format = schema_body.get("arrayFormat")
+    if array_format:
+        d["arrayFormat"] = array_format
+        d["arrayFormatLabel"] = ARRAY_FORMAT_LABELS.get(array_format, array_format)
+    if schema_body.get("dtype"):
+        d["dtype"] = schema_body["dtype"]
+    if schema_body.get("shape"):
+        d["shape"] = schema_body["shape"]
+    if schema_body.get("dimensionNames"):
+        d["dimensionNames"] = schema_body["dimensionNames"]
+
     return d
 
 


### PR DESCRIPTION
## Summary

- Add `KNOWN_ARRAY_FORMATS` constant and `ARRAY_FORMAT_LABELS` display-name mapping for all six recognized array format tokens (`numpyBytes`, `parquetBytes`, `sparseBytes`, `structuredBytes`, `arrowTensor`, `safetensors`)
- Update `row_to_schema()` to surface `arrayFormat`, `dtype`, `shape`, and `dimensionNames` from `schema_body` as top-level convenience fields for templates and API consumers
- Update frontend templates (schema detail, schemas list, profile, dataset detail) to display array format and ndarray annotation fields when present
- Update MCP server instructions and `get_schema` docstring to describe new format types
- Add 14 new tests covering all format tokens, ndarray annotations, partial annotations, unknown format passthrough, template rendering, and constant completeness

Closes #30

## Test plan

- [x] All 159 tests pass (`uv run pytest`)
- [x] Lint clean (`uv run ruff check src/ tests/`)
- [ ] Verify schema detail page renders array format and annotation rows for a schema with `arrayFormat` in its body
- [ ] Verify schemas list and profile pages show the new Format column
- [ ] Verify dataset detail page shows inline schema format info when the referenced schema has array format fields
- [ ] Verify plain schemas (no `arrayFormat`) render unchanged — no extra rows or columns with empty values

🤖 Generated with [Claude Code](https://claude.com/claude-code)