### PR TITLE
release: v0.4.0b1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
@@ -28,6 +30,8 @@ jobs:
         python-version: ["3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
@@ -56,6 +60,8 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - name: Apply schema
         env:
           PGHOST: localhost
@@ -105,6 +111,8 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lexicons"]
+	path = lexicons
+	url = https://github.com/forecast-bio/atdata-lexicon.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.4.0b1] - 2026-02-26
+
+### Added
+
+- `sendInteractions` XRPC procedure for anonymous usage telemetry — fire-and-forget reporting of download, citation, and derivative events on datasets ([#21](https://github.com/forecast-bio/atdata-app/issues/21))
+- Skeleton/hydration pattern for third-party dataset indexes — `getIndexSkeleton`, `getIndex`, `listIndexes`, and `publishIndex` endpoints following Bluesky's feed generator model ([#20](https://github.com/forecast-bio/atdata-app/issues/20))
+- `subscribeChanges` WebSocket endpoint for real-time change streaming — in-memory event bus broadcasts create/update/delete events to subscribers with cursor-based replay ([#22](https://github.com/forecast-bio/atdata-app/issues/22))
+- Array format type recognition (`sparseBytes`, `structuredBytes`, `arrowTensor`, `safetensors`) and ndarray v1.1.0 annotation display (`dtype`, `shape`, `dimensionNames`) in frontend templates ([#30](https://github.com/forecast-bio/atdata-app/issues/30))
+- `atdata-lexicon` git submodule at `lexicons/` pinned to v0.2.1b1 for reference and CI validation ([#27](https://github.com/forecast-bio/atdata-app/issues/27))
+- CI checkout steps now initialize submodules
+
+### Changed
+
+- Ingestion processor refactored to use `UPSERT_FNS` dispatch dict instead of if/elif chain
+- Index provider records (`science.alt.dataset.index`) added to `COLLECTION_TABLE_MAP` for firehose ingestion
+
 ## [0.3.0b1] - 2026-02-22
 
 ### Changed
@@ -19,8 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - DID document service entry updated from `#atproto_appview` / `AtprotoAppView` to `#atdata_appview` / `AtdataAppView`
 
 ### Added
-- Add real-time change stream subscribeChanges endpoint (#50)
-- Add sendInteractions XRPC procedure for usage telemetry (#35)
 
 - Dual-hostname DID document support — serve different `did:web` documents for `api.atdata.app` (appview identity) and `atdata.app` (atproto account identity) based on the `Host` header ([#19](https://github.com/forecast-bio/atdata-app/issues/19))
 - Host-based route gating middleware — frontend HTML routes are only served on the frontend hostname; the API subdomain serves only XRPC, health, and DID endpoints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - DID document service entry updated from `#atproto_appview` / `AtprotoAppView` to `#atdata_appview` / `AtdataAppView`
 
 ### Added
+- Add real-time change stream subscribeChanges endpoint (#50)
 
 - Dual-hostname DID document support — serve different `did:web` documents for `api.atdata.app` (appview identity) and `atdata.app` (atproto account identity) based on the `Host` header ([#19](https://github.com/forecast-bio/atdata-app/issues/19))
 - Host-based route gating middleware — frontend HTML routes are only served on the frontend hostname; the API subdomain serves only XRPC, health, and DID endpoints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - DID document service entry updated from `#atproto_appview` / `AtprotoAppView` to `#atdata_appview` / `AtdataAppView`
 
 ### Added
+- Adversarial review: sendInteractions feature and surrounding code (round 3) (#39)
+- Add sendInteractions XRPC procedure for usage telemetry (#35)
 
 - Dual-hostname DID document support — serve different `did:web` documents for `api.atdata.app` (appview identity) and `atdata.app` (atproto account identity) based on the `Host` header ([#19](https://github.com/forecast-bio/atdata-app/issues/19))
 - Host-based route gating middleware — frontend HTML routes are only served on the frontend hostname; the API subdomain serves only XRPC, health, and DID endpoints

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,16 @@ uv run ruff check src/ tests/
 uv run uvicorn atdata_app.main:app --reload
 ```
 
+## Lexicon Submodule
+
+The `lexicons/` directory is a git submodule pointing to [forecast-bio/atdata-lexicon](https://github.com/forecast-bio/atdata-lexicon), which contains the authoritative `science.alt.dataset.*` lexicon definitions. The submodule is for reference and CI validation — the Python source code does not read lexicon files at runtime.
+
+After cloning, initialize the submodule:
+
+```bash
+git submodule update --init
+```
+
 ## Architecture
 
 ### Data Flow

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ ATProto Network
 # Install dependencies
 uv sync --dev
 
+# Initialize the lexicon submodule
+git submodule update --init
+
 # Set up PostgreSQL (schema auto-applies on startup)
 createdb atdata_app
 
@@ -134,6 +137,16 @@ uv run ruff check src/ tests/
 ```
 
 Tests mock all external dependencies (database, HTTP, identity resolution) using `unittest.mock.AsyncMock`. HTTP endpoint tests use httpx `ASGITransport` for in-process testing without a running server.
+
+### Lexicon Definitions
+
+The `lexicons/` directory is a [git submodule](https://github.com/forecast-bio/atdata-lexicon) containing the authoritative `science.alt.dataset.*` lexicon schemas. Initialize it with:
+
+```bash
+git submodule update --init
+```
+
+The lexicons are for reference and CI validation. The Python source code uses hardcoded NSID constants and does not read the lexicon JSON files at runtime.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "atdata-app"
-version = "0.3.0b1"
+version = "0.4.0b1"
 description = "ATProto AppView for science.alt.dataset"
 readme = "README.md"
 authors = [

--- a/src/atdata_app/changestream.py
+++ b/src/atdata_app/changestream.py
@@ -1,0 +1,152 @@
+"""In-memory broadcast channel for real-time change events.
+
+Provides a pub/sub mechanism that the ingestion processor publishes to
+and WebSocket subscribers consume from. Maintains a bounded buffer of
+recent events for cursor-based replay.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BUFFER_SIZE = 1000
+DEFAULT_SUBSCRIBER_QUEUE_SIZE = 256
+
+
+@dataclass
+class ChangeEvent:
+    """A single change event in the stream."""
+
+    seq: int
+    type: str  # "create", "update", or "delete"
+    collection: str
+    did: str
+    rkey: str
+    timestamp: str
+    record: dict[str, Any] | None = None
+    cid: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {
+            "seq": self.seq,
+            "type": self.type,
+            "collection": self.collection,
+            "did": self.did,
+            "rkey": self.rkey,
+            "timestamp": self.timestamp,
+        }
+        if self.record is not None:
+            d["record"] = self.record
+        if self.cid is not None:
+            d["cid"] = self.cid
+        return d
+
+
+@dataclass
+class ChangeStream:
+    """Broadcast channel with bounded replay buffer.
+
+    Thread-safe for asyncio: all mutations happen in the event loop.
+    """
+
+    buffer_size: int = DEFAULT_BUFFER_SIZE
+    subscriber_queue_size: int = DEFAULT_SUBSCRIBER_QUEUE_SIZE
+    _seq: int = field(default=0, init=False)
+    _buffer: deque[ChangeEvent] = field(init=False)
+    _subscribers: dict[int, asyncio.Queue[ChangeEvent]] = field(
+        default_factory=dict, init=False
+    )
+    _next_sub_id: int = field(default=0, init=False)
+
+    def __post_init__(self) -> None:
+        self._buffer = deque(maxlen=self.buffer_size)
+
+    def publish(self, event: ChangeEvent) -> None:
+        """Publish an event to all subscribers and the replay buffer.
+
+        Non-blocking. If a subscriber's queue is full, the event is dropped
+        for that subscriber (backpressure via disconnect is handled by the
+        WebSocket handler).
+        """
+        self._seq += 1
+        event.seq = self._seq
+        self._buffer.append(event)
+
+        for sub_id, queue in list(self._subscribers.items()):
+            try:
+                queue.put_nowait(event)
+            except asyncio.QueueFull:
+                logger.warning(
+                    "Subscriber %d queue full, dropping event seq=%d",
+                    sub_id,
+                    event.seq,
+                )
+
+    def subscribe(self) -> tuple[int, asyncio.Queue[ChangeEvent]]:
+        """Create a new subscriber. Returns (subscriber_id, queue)."""
+        sub_id = self._next_sub_id
+        self._next_sub_id += 1
+        queue: asyncio.Queue[ChangeEvent] = asyncio.Queue(
+            maxsize=self.subscriber_queue_size
+        )
+        self._subscribers[sub_id] = queue
+        logger.debug("Subscriber %d connected (total: %d)", sub_id, len(self._subscribers))
+        return sub_id, queue
+
+    def unsubscribe(self, sub_id: int) -> None:
+        """Remove a subscriber."""
+        self._subscribers.pop(sub_id, None)
+        logger.debug("Subscriber %d disconnected (total: %d)", sub_id, len(self._subscribers))
+
+    def replay_from(self, cursor: int) -> list[ChangeEvent]:
+        """Return buffered events with seq > cursor.
+
+        Returns an empty list if the cursor is outside the buffer window.
+        """
+        if not self._buffer:
+            return []
+
+        oldest_seq = self._buffer[0].seq
+        if cursor < oldest_seq - 1:
+            # Cursor is too old — events between cursor and buffer start were lost
+            return []
+
+        return [ev for ev in self._buffer if ev.seq > cursor]
+
+    @property
+    def current_seq(self) -> int:
+        return self._seq
+
+    @property
+    def subscriber_count(self) -> int:
+        return len(self._subscribers)
+
+
+def make_change_event(
+    *,
+    event_type: str,
+    collection: str,
+    did: str,
+    rkey: str,
+    record: dict[str, Any] | None = None,
+    cid: str | None = None,
+) -> ChangeEvent:
+    """Factory for creating change events with current timestamp."""
+    from datetime import datetime, timezone
+
+    return ChangeEvent(
+        seq=0,  # Assigned by ChangeStream.publish()
+        type=event_type,
+        collection=collection,
+        did=did,
+        rkey=rkey,
+        timestamp=datetime.now(timezone.utc).isoformat(),
+        record=record,
+        cid=cid,
+    )

--- a/src/atdata_app/database.py
+++ b/src/atdata_app/database.py
@@ -366,11 +366,18 @@ async def query_get_entry(
         )
 
 
+_MAX_GET_ENTRIES_KEYS = 100
+
+
 async def query_get_entries(
     pool: asyncpg.Pool, keys: list[tuple[str, str]]
 ) -> list[asyncpg.Record]:
     if not keys:
         return []
+    if len(keys) > _MAX_GET_ENTRIES_KEYS:
+        raise ValueError(
+            f"query_get_entries: too many keys ({len(keys)}), max {_MAX_GET_ENTRIES_KEYS}"
+        )
     conditions = " OR ".join(
         f"(did = ${i * 2 + 1} AND rkey = ${i * 2 + 2})" for i in range(len(keys))
     )

--- a/src/atdata_app/database.py
+++ b/src/atdata_app/database.py
@@ -720,7 +720,10 @@ async def query_entry_stats(
             """
             SELECT
                 COUNT(*) FILTER (WHERE event_type = 'view_entry') AS views,
-                COUNT(*) FILTER (WHERE event_type = 'search') AS search_appearances
+                COUNT(*) FILTER (WHERE event_type = 'search') AS search_appearances,
+                COUNT(*) FILTER (WHERE event_type = 'download') AS downloads,
+                COUNT(*) FILTER (WHERE event_type = 'citation') AS citations,
+                COUNT(*) FILTER (WHERE event_type = 'derivative') AS derivatives
             FROM analytics_events
             WHERE target_did = $1 AND target_rkey = $2
               AND created_at >= NOW() - $3::interval
@@ -732,6 +735,9 @@ async def query_entry_stats(
         return {
             "views": row["views"],
             "searchAppearances": row["search_appearances"],
+            "downloads": row["downloads"],
+            "citations": row["citations"],
+            "derivatives": row["derivatives"],
             "period": period,
         }
 

--- a/src/atdata_app/database.py
+++ b/src/atdata_app/database.py
@@ -825,6 +825,8 @@ async def query_active_publishers(pool: asyncpg.Pool, days: int = 30) -> int:
                 SELECT did FROM labels WHERE indexed_at >= NOW() - $1::interval
                 UNION
                 SELECT did FROM lenses WHERE indexed_at >= NOW() - $1::interval
+                UNION
+                SELECT did FROM index_providers WHERE indexed_at >= NOW() - $1::interval
             ) sub
             """,
             interval,

--- a/src/atdata_app/database.py
+++ b/src/atdata_app/database.py
@@ -20,6 +20,7 @@ COLLECTION_TABLE_MAP: dict[str, str] = {
     f"{LEXICON_NAMESPACE}.entry": "entries",
     f"{LEXICON_NAMESPACE}.label": "labels",
     f"{LEXICON_NAMESPACE}.lens": "lenses",
+    f"{LEXICON_NAMESPACE}.index": "index_providers",
 }
 
 
@@ -203,6 +204,36 @@ async def upsert_lens(
         )
 
 
+async def upsert_index_provider(
+    pool: asyncpg.Pool,
+    did: str,
+    rkey: str,
+    cid: str | None,
+    record: dict[str, Any],
+) -> None:
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO index_providers (did, rkey, cid, name, description, endpoint_url,
+                                         created_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7)
+            ON CONFLICT (did, rkey) DO UPDATE SET
+                cid = EXCLUDED.cid,
+                name = EXCLUDED.name,
+                description = EXCLUDED.description,
+                endpoint_url = EXCLUDED.endpoint_url,
+                indexed_at = NOW()
+            """,
+            did,
+            rkey,
+            cid,
+            record["name"],
+            record.get("description"),
+            record["endpointUrl"],
+            record.get("createdAt", ""),
+        )
+
+
 async def delete_record(pool: asyncpg.Pool, table: str, did: str, rkey: str) -> None:
     if table not in COLLECTION_TABLE_MAP.values():
         return
@@ -219,6 +250,7 @@ UPSERT_FNS = {
     "entries": upsert_entry,
     "labels": upsert_label,
     "lenses": upsert_lens,
+    "index_providers": upsert_index_provider,
 }
 
 
@@ -445,6 +477,49 @@ async def query_list_lenses(
     async with pool.acquire() as conn:
         return await conn.fetch(
             f"SELECT * FROM lenses {where} ORDER BY indexed_at DESC, did DESC, rkey DESC LIMIT ${idx}",
+            *params,
+        )
+
+
+async def query_get_index_provider(
+    pool: asyncpg.Pool, did: str, rkey: str
+) -> asyncpg.Record | None:
+    async with pool.acquire() as conn:
+        return await conn.fetchrow(
+            "SELECT * FROM index_providers WHERE did = $1 AND rkey = $2", did, rkey
+        )
+
+
+async def query_list_index_providers(
+    pool: asyncpg.Pool,
+    repo: str | None = None,
+    limit: int = 50,
+    cursor_did: str | None = None,
+    cursor_rkey: str | None = None,
+    cursor_indexed_at: str | None = None,
+) -> list[asyncpg.Record]:
+    conditions: list[str] = []
+    params: list[Any] = []
+    idx = 1
+
+    if repo:
+        conditions.append(f"did = ${idx}")
+        params.append(repo)
+        idx += 1
+
+    if cursor_indexed_at and cursor_did and cursor_rkey:
+        conditions.append(
+            f"(indexed_at, did, rkey) < (${idx}, ${idx + 1}, ${idx + 2})"
+        )
+        params.extend([datetime.fromisoformat(cursor_indexed_at), cursor_did, cursor_rkey])
+        idx += 3
+
+    where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+    params.append(limit)
+
+    async with pool.acquire() as conn:
+        return await conn.fetch(
+            f"SELECT * FROM index_providers {where} ORDER BY indexed_at DESC, did DESC, rkey DESC LIMIT ${idx}",
             *params,
         )
 

--- a/src/atdata_app/frontend/routes.py
+++ b/src/atdata_app/frontend/routes.py
@@ -22,6 +22,7 @@ from atdata_app.database import (
 )
 from atdata_app.models import (
     maybe_cursor,
+    parse_at_uri,
     parse_cursor,
     row_to_entry,
     row_to_label,
@@ -100,10 +101,11 @@ async def dataset_detail(request: Request, did: str, rkey: str):
     schema_did = ""
     schema_rkey = ""
     schema_ref = entry.get("schemaRef", "")
-    if schema_ref.startswith("at://"):
-        parts = schema_ref[5:].split("/", 2)
-        if len(parts) == 3:
-            schema_did, _, schema_rkey = parts
+    if schema_ref:
+        try:
+            schema_did, _, schema_rkey = parse_at_uri(schema_ref)
+        except ValueError:
+            pass
 
     # Fetch labels pointing to this dataset
     dataset_uri = entry["uri"]

--- a/src/atdata_app/frontend/routes.py
+++ b/src/atdata_app/frontend/routes.py
@@ -105,6 +105,13 @@ async def dataset_detail(request: Request, did: str, rkey: str):
         if len(parts) == 3:
             schema_did, _, schema_rkey = parts
 
+    # Fetch the referenced schema for inline display of format/annotation info
+    schema_info = None
+    if schema_did and schema_rkey:
+        schema_row = await query_get_schema(pool, schema_did, schema_rkey)
+        if schema_row:
+            schema_info = row_to_schema(schema_row)
+
     # Fetch labels pointing to this dataset
     dataset_uri = entry["uri"]
     label_rows = await query_labels_for_dataset(pool, dataset_uri)
@@ -117,6 +124,7 @@ async def dataset_detail(request: Request, did: str, rkey: str):
             "entry": entry,
             "schema_did": schema_did,
             "schema_rkey": schema_rkey,
+            "schema_info": schema_info,
             "labels": labels,
         },
     )

--- a/src/atdata_app/frontend/templates/dataset.html
+++ b/src/atdata_app/frontend/templates/dataset.html
@@ -34,10 +34,10 @@
             {% if schema_info.dtype is defined %}
             <tr><th>Data Type</th><td><code>{{ schema_info.dtype }}</code></td></tr>
             {% endif %}
-            {% if schema_info.shape is defined %}
+            {% if schema_info.shape is defined and schema_info.shape is iterable and schema_info.shape is not string %}
             <tr><th>Shape</th><td><code>{{ schema_info.shape | join(" × ") }}</code></td></tr>
             {% endif %}
-            {% if schema_info.dimensionNames is defined %}
+            {% if schema_info.dimensionNames is defined and schema_info.dimensionNames is iterable and schema_info.dimensionNames is not string %}
             <tr><th>Dimensions</th><td>{{ schema_info.dimensionNames | join(", ") }}</td></tr>
             {% endif %}
             {% endif %}
@@ -63,7 +63,11 @@
         <tbody>
             <tr><th>Type</th><td><code>{{ entry.storage.get("$type", "unknown") }}</code></td></tr>
             {% if entry.storage.url is defined %}
+            {% if entry.storage.url.startswith("https://") or entry.storage.url.startswith("http://") %}
             <tr><th>URL</th><td><a href="{{ entry.storage.url }}">{{ entry.storage.url }}</a></td></tr>
+            {% else %}
+            <tr><th>URL</th><td>{{ entry.storage.url }}</td></tr>
+            {% endif %}
             {% endif %}
         </tbody>
     </table>

--- a/src/atdata_app/frontend/templates/dataset.html
+++ b/src/atdata_app/frontend/templates/dataset.html
@@ -27,6 +27,20 @@
             <tr><th>License</th><td>{{ entry.license }}</td></tr>
             {% endif %}
             <tr><th>Schema</th><td><a href="/schema/{{ schema_did }}/{{ schema_rkey }}">{{ entry.schemaRef }}</a></td></tr>
+            {% if schema_info %}
+            {% if schema_info.arrayFormat is defined %}
+            <tr><th>Array Format</th><td>{{ schema_info.get("arrayFormatLabel", schema_info.arrayFormat) }}</td></tr>
+            {% endif %}
+            {% if schema_info.dtype is defined %}
+            <tr><th>Data Type</th><td><code>{{ schema_info.dtype }}</code></td></tr>
+            {% endif %}
+            {% if schema_info.shape is defined %}
+            <tr><th>Shape</th><td><code>{{ schema_info.shape | join(" × ") }}</code></td></tr>
+            {% endif %}
+            {% if schema_info.dimensionNames is defined %}
+            <tr><th>Dimensions</th><td>{{ schema_info.dimensionNames | join(", ") }}</td></tr>
+            {% endif %}
+            {% endif %}
             {% if entry.size %}
             <tr>
                 <th>Size</th>

--- a/src/atdata_app/frontend/templates/profile.html
+++ b/src/atdata_app/frontend/templates/profile.html
@@ -34,13 +34,14 @@
     <h2>Schemas</h2>
     {% if schemas %}
     <table>
-        <thead><tr><th>Name</th><th>Version</th><th>Type</th></tr></thead>
+        <thead><tr><th>Name</th><th>Version</th><th>Type</th><th>Format</th></tr></thead>
         <tbody>
             {% for s in schemas %}
             <tr>
                 <td><a href="/schema/{{ s.did }}/{{ s.rkey }}">{{ s.name }}</a></td>
                 <td>{{ s.version }}</td>
                 <td>{{ s.schemaType }}</td>
+                <td>{{ s.get("arrayFormatLabel", "") }}</td>
             </tr>
             {% endfor %}
         </tbody>

--- a/src/atdata_app/frontend/templates/schema.html
+++ b/src/atdata_app/frontend/templates/schema.html
@@ -22,10 +22,10 @@
             {% if schema.dtype is defined %}
             <tr><th>Data Type</th><td><code>{{ schema.dtype }}</code></td></tr>
             {% endif %}
-            {% if schema.shape is defined %}
+            {% if schema.shape is defined and schema.shape is iterable and schema.shape is not string %}
             <tr><th>Shape</th><td><code>{{ schema.shape | join(" × ") }}</code></td></tr>
             {% endif %}
-            {% if schema.dimensionNames is defined %}
+            {% if schema.dimensionNames is defined and schema.dimensionNames is iterable and schema.dimensionNames is not string %}
             <tr><th>Dimensions</th><td>{{ schema.dimensionNames | join(", ") }}</td></tr>
             {% endif %}
             <tr><th>Version</th><td>{{ schema.version }}</td></tr>

--- a/src/atdata_app/frontend/templates/schema.html
+++ b/src/atdata_app/frontend/templates/schema.html
@@ -16,6 +16,18 @@
         <tbody>
             <tr><th>AT-URI</th><td><code>{{ schema.uri }}</code></td></tr>
             <tr><th>Type</th><td>{{ schema.schemaType }}</td></tr>
+            {% if schema.arrayFormat is defined %}
+            <tr><th>Array Format</th><td>{{ schema.get("arrayFormatLabel", schema.arrayFormat) }}</td></tr>
+            {% endif %}
+            {% if schema.dtype is defined %}
+            <tr><th>Data Type</th><td><code>{{ schema.dtype }}</code></td></tr>
+            {% endif %}
+            {% if schema.shape is defined %}
+            <tr><th>Shape</th><td><code>{{ schema.shape | join(" × ") }}</code></td></tr>
+            {% endif %}
+            {% if schema.dimensionNames is defined %}
+            <tr><th>Dimensions</th><td>{{ schema.dimensionNames | join(", ") }}</td></tr>
+            {% endif %}
             <tr><th>Version</th><td>{{ schema.version }}</td></tr>
             <tr><th>Created</th><td>{{ schema.createdAt }}</td></tr>
         </tbody>

--- a/src/atdata_app/frontend/templates/schemas.html
+++ b/src/atdata_app/frontend/templates/schemas.html
@@ -7,7 +7,7 @@
     {% if schemas %}
     <table>
         <thead>
-            <tr><th>Name</th><th>Version</th><th>Type</th><th>Description</th><th>Publisher</th></tr>
+            <tr><th>Name</th><th>Version</th><th>Type</th><th>Format</th><th>Description</th><th>Publisher</th></tr>
         </thead>
         <tbody>
             {% for s in schemas %}
@@ -15,6 +15,7 @@
                 <td><a href="/schema/{{ s.did }}/{{ s.rkey }}">{{ s.name }}</a></td>
                 <td>{{ s.version }}</td>
                 <td>{{ s.schemaType }}</td>
+                <td>{{ s.get("arrayFormatLabel", "") }}</td>
                 <td>{{ s.get("description", "") }}</td>
                 <td><a href="/profile/{{ s.did }}">{{ s.did[:20] }}…</a></td>
             </tr>

--- a/src/atdata_app/ingestion/jetstream.py
+++ b/src/atdata_app/ingestion/jetstream.py
@@ -52,7 +52,9 @@ async def jetstream_consumer(app: FastAPI) -> None:
                     if event.get("kind") != "commit":
                         continue
 
-                    await process_commit(pool, event)
+                    await process_commit(
+                        pool, event, getattr(app.state, "change_stream", None)
+                    )
 
                     last_time_us = event.get("time_us")
                     msg_count += 1

--- a/src/atdata_app/ingestion/processor.py
+++ b/src/atdata_app/ingestion/processor.py
@@ -48,14 +48,7 @@ async def process_commit(pool: asyncpg.Pool, event: dict[str, Any]) -> None:
         record = commit["record"]
         cid = commit.get("cid")
         try:
-            if table == "schemas":
-                await db.upsert_schema(pool, did, rkey, cid, record)
-            elif table == "entries":
-                await db.upsert_entry(pool, did, rkey, cid, record)
-            elif table == "labels":
-                await db.upsert_label(pool, did, rkey, cid, record)
-            elif table == "lenses":
-                await db.upsert_lens(pool, did, rkey, cid, record)
+            await db.UPSERT_FNS[table](pool, did, rkey, cid, record)
             logger.debug("Upserted %s %s/%s", collection, did, rkey)
         except Exception:
             logger.exception("Failed to upsert %s %s/%s", collection, did, rkey)

--- a/src/atdata_app/ingestion/processor.py
+++ b/src/atdata_app/ingestion/processor.py
@@ -56,6 +56,8 @@ async def process_commit(pool: asyncpg.Pool, event: dict[str, Any]) -> None:
                 await db.upsert_label(pool, did, rkey, cid, record)
             elif table == "lenses":
                 await db.upsert_lens(pool, did, rkey, cid, record)
+            elif table == "index_providers":
+                await db.upsert_index_provider(pool, did, rkey, cid, record)
             logger.debug("Upserted %s %s/%s", collection, did, rkey)
         except Exception:
             logger.exception("Failed to upsert %s %s/%s", collection, did, rkey)

--- a/src/atdata_app/ingestion/processor.py
+++ b/src/atdata_app/ingestion/processor.py
@@ -8,11 +8,16 @@ from typing import Any
 import asyncpg
 
 from atdata_app import database as db
+from atdata_app.changestream import ChangeStream, make_change_event
 
 logger = logging.getLogger(__name__)
 
 
-async def process_commit(pool: asyncpg.Pool, event: dict[str, Any]) -> None:
+async def process_commit(
+    pool: asyncpg.Pool,
+    event: dict[str, Any],
+    change_stream: ChangeStream | None = None,
+) -> None:
     """Process a Jetstream commit event.
 
     Expected event format::
@@ -44,6 +49,15 @@ async def process_commit(pool: asyncpg.Pool, event: dict[str, Any]) -> None:
     if operation == "delete":
         await db.delete_record(pool, table, did, rkey)
         logger.debug("Deleted %s %s/%s", collection, did, rkey)
+        if change_stream is not None:
+            change_stream.publish(
+                make_change_event(
+                    event_type="delete",
+                    collection=collection,
+                    did=did,
+                    rkey=rkey,
+                )
+            )
     elif operation in ("create", "update"):
         record = commit["record"]
         cid = commit.get("cid")
@@ -57,5 +71,16 @@ async def process_commit(pool: asyncpg.Pool, event: dict[str, Any]) -> None:
             elif table == "lenses":
                 await db.upsert_lens(pool, did, rkey, cid, record)
             logger.debug("Upserted %s %s/%s", collection, did, rkey)
+            if change_stream is not None:
+                change_stream.publish(
+                    make_change_event(
+                        event_type=operation,
+                        collection=collection,
+                        did=did,
+                        rkey=rkey,
+                        record=record,
+                        cid=cid,
+                    )
+                )
         except Exception:
             logger.exception("Failed to upsert %s %s/%s", collection, did, rkey)

--- a/src/atdata_app/main.py
+++ b/src/atdata_app/main.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI, Request, Response
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 
+from atdata_app.changestream import ChangeStream
 from atdata_app.config import AppConfig
 from atdata_app.database import create_pool, run_migrations
 from atdata_app.frontend import router as frontend_router
@@ -29,6 +30,9 @@ _SHARED_PATH_PREFIXES = ("/xrpc/", "/.well-known/", "/health")
 async def lifespan(app: FastAPI):
     config: AppConfig = app.state.config
     logger.info("Starting atdata-app (DID: %s)", config.service_did)
+
+    # Change stream (must be created before background tasks)
+    app.state.change_stream = ChangeStream()
 
     # Database
     pool = await create_pool(config.database_url)

--- a/src/atdata_app/mcp_server.py
+++ b/src/atdata_app/mcp_server.py
@@ -57,7 +57,10 @@ mcp_server = FastMCP(
         "ATProto AppView for the science.alt.dataset namespace. "
         "Use these tools to discover and query scientific datasets, "
         "schemas, and lenses (bidirectional schema transforms) published "
-        "on the AT Protocol network."
+        "on the AT Protocol network. "
+        "Schemas may specify an arrayFormat (numpyBytes, parquetBytes, "
+        "sparseBytes, structuredBytes, arrowTensor, safetensors) and "
+        "ndarray annotations (dtype, shape, dimensionNames)."
     ),
     lifespan=server_lifespan,
 )
@@ -127,7 +130,8 @@ async def get_schema(ctx: Ctx, uri: str) -> dict[str, Any]:
         uri: AT-URI of the schema (e.g. at://did:plc:abc/science.alt.dataset.schema/my.schema@1.0.0).
 
     Returns:
-        Full schema record including name, version, type, schema body, and description.
+        Full schema record including name, version, type, schema body, description,
+        and (when present) arrayFormat, dtype, shape, and dimensionNames.
     """
     sc = _get_ctx(ctx)
     did, _collection, rkey = parse_at_uri(uri)

--- a/src/atdata_app/models.py
+++ b/src/atdata_app/models.py
@@ -10,6 +10,32 @@ from pydantic import BaseModel
 
 
 # ---------------------------------------------------------------------------
+# Known array format tokens (atdata-lexicon#21)
+# ---------------------------------------------------------------------------
+
+KNOWN_ARRAY_FORMATS: set[str] = {
+    # Original formats
+    "numpyBytes",
+    "parquetBytes",
+    # New formats
+    "sparseBytes",
+    "structuredBytes",
+    "arrowTensor",
+    "safetensors",
+}
+
+#: Human-friendly display names for array format tokens.
+ARRAY_FORMAT_LABELS: dict[str, str] = {
+    "numpyBytes": "NumPy ndarray",
+    "parquetBytes": "Parquet",
+    "sparseBytes": "Sparse matrix (CSR/CSC/COO)",
+    "structuredBytes": "NumPy structured array",
+    "arrowTensor": "Arrow tensor IPC",
+    "safetensors": "Safetensors",
+}
+
+
+# ---------------------------------------------------------------------------
 # AT-URI parsing
 # ---------------------------------------------------------------------------
 
@@ -119,6 +145,19 @@ def row_to_schema(row) -> dict[str, Any]:
     }
     if row["description"]:
         d["description"] = row["description"]
+
+    # Surface array format and ndarray v1.1.0 annotation fields for display
+    array_format = schema_body.get("arrayFormat")
+    if array_format:
+        d["arrayFormat"] = array_format
+        d["arrayFormatLabel"] = ARRAY_FORMAT_LABELS.get(array_format, array_format)
+    if schema_body.get("dtype"):
+        d["dtype"] = schema_body["dtype"]
+    if schema_body.get("shape"):
+        d["shape"] = schema_body["shape"]
+    if schema_body.get("dimensionNames"):
+        d["dimensionNames"] = schema_body["dimensionNames"]
+
     return d
 
 

--- a/src/atdata_app/models.py
+++ b/src/atdata_app/models.py
@@ -236,4 +236,7 @@ class GetAnalyticsResponse(BaseModel):
 class GetEntryStatsResponse(BaseModel):
     views: int
     searchAppearances: int
+    downloads: int = 0
+    citations: int = 0
+    derivatives: int = 0
     period: str

--- a/src/atdata_app/models.py
+++ b/src/atdata_app/models.py
@@ -127,6 +127,7 @@ def row_to_label(row) -> dict[str, Any]:
     d: dict[str, Any] = {
         "uri": uri,
         "cid": row["cid"],
+        "did": row["did"],
         "name": row["name"],
         "datasetUri": row["dataset_uri"],
         "createdAt": row["created_at"],
@@ -150,6 +151,7 @@ def row_to_lens(row) -> dict[str, Any]:
     d: dict[str, Any] = {
         "uri": uri,
         "cid": row["cid"],
+        "did": row["did"],
         "name": row["name"],
         "sourceSchema": row["source_schema"],
         "targetSchema": row["target_schema"],

--- a/src/atdata_app/models.py
+++ b/src/atdata_app/models.py
@@ -138,6 +138,21 @@ def row_to_label(row) -> dict[str, Any]:
     return d
 
 
+def row_to_index_provider(row) -> dict[str, Any]:
+    uri = make_at_uri(row["did"], "science.alt.dataset.index", row["rkey"])
+    d: dict[str, Any] = {
+        "uri": uri,
+        "cid": row["cid"],
+        "did": row["did"],
+        "name": row["name"],
+        "endpointUrl": row["endpoint_url"],
+        "createdAt": row["created_at"],
+    }
+    if row["description"]:
+        d["description"] = row["description"]
+    return d
+
+
 def row_to_lens(row) -> dict[str, Any]:
     uri = make_at_uri(row["did"], "science.alt.dataset.lens", row["rkey"])
     getter_code = row["getter_code"]
@@ -237,3 +252,18 @@ class GetEntryStatsResponse(BaseModel):
     views: int
     searchAppearances: int
     period: str
+
+
+class ListIndexesResponse(BaseModel):
+    indexes: list[dict[str, Any]]
+    cursor: str | None = None
+
+
+class IndexSkeletonResponse(BaseModel):
+    items: list[dict[str, Any]]
+    cursor: str | None = None
+
+
+class IndexResponse(BaseModel):
+    items: list[dict[str, Any]]
+    cursor: str | None = None

--- a/src/atdata_app/models.py
+++ b/src/atdata_app/models.py
@@ -127,6 +127,7 @@ def row_to_label(row) -> dict[str, Any]:
     d: dict[str, Any] = {
         "uri": uri,
         "cid": row["cid"],
+        "did": row["did"],
         "name": row["name"],
         "datasetUri": row["dataset_uri"],
         "createdAt": row["created_at"],
@@ -165,6 +166,7 @@ def row_to_lens(row) -> dict[str, Any]:
     d: dict[str, Any] = {
         "uri": uri,
         "cid": row["cid"],
+        "did": row["did"],
         "name": row["name"],
         "sourceSchema": row["source_schema"],
         "targetSchema": row["target_schema"],

--- a/src/atdata_app/sql/schema.sql
+++ b/src/atdata_app/sql/schema.sql
@@ -144,6 +144,22 @@ CREATE INDEX IF NOT EXISTS idx_analytics_events_type_created
 CREATE INDEX IF NOT EXISTS idx_analytics_events_target
     ON analytics_events (target_did, target_rkey, event_type);
 
+-- Index providers (science.alt.dataset.index)
+CREATE TABLE IF NOT EXISTS index_providers (
+    did          TEXT NOT NULL,
+    rkey         TEXT NOT NULL,
+    cid          TEXT,
+    name         TEXT NOT NULL,
+    description  TEXT,
+    endpoint_url TEXT NOT NULL,
+    created_at   TEXT NOT NULL,
+    indexed_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (did, rkey)
+);
+
+CREATE INDEX IF NOT EXISTS idx_index_providers_did ON index_providers (did);
+CREATE INDEX IF NOT EXISTS idx_index_providers_indexed_at ON index_providers (indexed_at DESC);
+
 -- Pre-aggregated analytics counters (avoids expensive COUNT on events table)
 CREATE TABLE IF NOT EXISTS analytics_counters (
     target_did   TEXT NOT NULL,

--- a/src/atdata_app/xrpc/procedures.py
+++ b/src/atdata_app/xrpc/procedures.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 from fastapi import APIRouter, HTTPException, Request
@@ -19,7 +20,6 @@ from atdata_app.database import (
     query_get_schema,
     query_record_exists,
 )
-from urllib.parse import urlparse
 from atdata_app.models import parse_at_uri
 
 logger = logging.getLogger(__name__)

--- a/src/atdata_app/xrpc/queries.py
+++ b/src/atdata_app/xrpc/queries.py
@@ -7,9 +7,9 @@ from typing import Any
 
 from fastapi import APIRouter, HTTPException, Query, Request
 
-from atdata_app import get_resolver
 import httpx
 
+from atdata_app import get_resolver
 from atdata_app.database import (
     COLLECTION_TABLE_MAP,
     fire_analytics_event,

--- a/src/atdata_app/xrpc/router.py
+++ b/src/atdata_app/xrpc/router.py
@@ -1,10 +1,12 @@
-"""Combined XRPC router mounting all query and procedure endpoints."""
+"""Combined XRPC router mounting all query, procedure, and subscription endpoints."""
 
 from fastapi import APIRouter
 
 from atdata_app.xrpc.procedures import router as procedures_router
 from atdata_app.xrpc.queries import router as queries_router
+from atdata_app.xrpc.subscriptions import router as subscriptions_router
 
 router = APIRouter(prefix="/xrpc")
 router.include_router(queries_router)
 router.include_router(procedures_router)
+router.include_router(subscriptions_router)

--- a/src/atdata_app/xrpc/subscriptions.py
+++ b/src/atdata_app/xrpc/subscriptions.py
@@ -1,0 +1,53 @@
+"""WebSocket subscription endpoints for real-time change streaming."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+from atdata_app.changestream import ChangeStream
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.websocket("/science.alt.dataset.subscribeChanges")
+async def subscribe_changes(websocket: WebSocket) -> None:
+    """Stream real-time change events over WebSocket.
+
+    Query parameters:
+        cursor: Optional sequence number to replay from.
+    """
+    change_stream: ChangeStream = websocket.app.state.change_stream
+
+    await websocket.accept()
+
+    cursor_param = websocket.query_params.get("cursor")
+    sub_id, queue = change_stream.subscribe()
+
+    try:
+        # Replay buffered events if cursor provided
+        if cursor_param is not None:
+            try:
+                cursor = int(cursor_param)
+            except (ValueError, TypeError):
+                await websocket.close(code=1008, reason="Invalid cursor value")
+                return
+            missed = change_stream.replay_from(cursor)
+            for event in missed:
+                await websocket.send_text(json.dumps(event.to_dict()))
+
+        # Stream live events
+        while True:
+            event = await queue.get()
+            await websocket.send_text(json.dumps(event.to_dict()))
+
+    except WebSocketDisconnect:
+        logger.debug("Subscriber %d disconnected", sub_id)
+    except Exception:
+        logger.exception("Error in subscriber %d", sub_id)
+    finally:
+        change_stream.unsubscribe(sub_id)

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -394,8 +394,10 @@ _PROC = "atdata_app.xrpc.procedures"
 
 
 @pytest.mark.asyncio
+@patch(f"{_PROC}.verify_service_auth", new_callable=AsyncMock)
 @patch(f"{_PROC}.fire_analytics_event")
-async def test_send_interactions_valid_batch(mock_fire, config, pool):
+async def test_send_interactions_valid_batch(mock_fire, mock_auth, config, pool):
+    mock_auth.return_value = MagicMock(iss="did:plc:caller")
     app = _mock_app(config, pool)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -424,8 +426,10 @@ async def test_send_interactions_valid_batch(mock_fire, config, pool):
 
 
 @pytest.mark.asyncio
+@patch(f"{_PROC}.verify_service_auth", new_callable=AsyncMock)
 @patch(f"{_PROC}.fire_analytics_event")
-async def test_send_interactions_empty_array(mock_fire, config, pool):
+async def test_send_interactions_empty_array(mock_fire, mock_auth, config, pool):
+    mock_auth.return_value = MagicMock(iss="did:plc:caller")
     app = _mock_app(config, pool)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -440,8 +444,10 @@ async def test_send_interactions_empty_array(mock_fire, config, pool):
 
 
 @pytest.mark.asyncio
+@patch(f"{_PROC}.verify_service_auth", new_callable=AsyncMock)
 @patch(f"{_PROC}.fire_analytics_event")
-async def test_send_interactions_invalid_uri(mock_fire, config, pool):
+async def test_send_interactions_invalid_uri(mock_fire, mock_auth, config, pool):
+    mock_auth.return_value = MagicMock(iss="did:plc:caller")
     app = _mock_app(config, pool)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -460,8 +466,10 @@ async def test_send_interactions_invalid_uri(mock_fire, config, pool):
 
 
 @pytest.mark.asyncio
+@patch(f"{_PROC}.verify_service_auth", new_callable=AsyncMock)
 @patch(f"{_PROC}.fire_analytics_event")
-async def test_send_interactions_invalid_type(mock_fire, config, pool):
+async def test_send_interactions_invalid_type(mock_fire, mock_auth, config, pool):
+    mock_auth.return_value = MagicMock(iss="did:plc:caller")
     app = _mock_app(config, pool)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -483,8 +491,10 @@ async def test_send_interactions_invalid_type(mock_fire, config, pool):
 
 
 @pytest.mark.asyncio
+@patch(f"{_PROC}.verify_service_auth", new_callable=AsyncMock)
 @patch(f"{_PROC}.fire_analytics_event")
-async def test_send_interactions_batch_size_exceeded(mock_fire, config, pool):
+async def test_send_interactions_batch_size_exceeded(mock_fire, mock_auth, config, pool):
+    mock_auth.return_value = MagicMock(iss="did:plc:caller")
     app = _mock_app(config, pool)
     transport = ASGITransport(app=app)
     interactions = [
@@ -503,8 +513,11 @@ async def test_send_interactions_batch_size_exceeded(mock_fire, config, pool):
 
 
 @pytest.mark.asyncio
+@patch(f"{_PROC}.verify_service_auth", new_callable=AsyncMock)
 @patch(f"{_PROC}.fire_analytics_event")
-async def test_send_interactions_invalid_timestamp(mock_fire, config, pool):
+async def test_send_interactions_ignores_timestamp(mock_fire, mock_auth, config, pool):
+    """Timestamp field is accepted but not validated (informational only)."""
+    mock_auth.return_value = MagicMock(iss="did:plc:caller")
     app = _mock_app(config, pool)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -521,14 +534,15 @@ async def test_send_interactions_invalid_timestamp(mock_fire, config, pool):
             },
         )
 
-    assert resp.status_code == 400
-    assert "invalid ISO 8601 timestamp" in resp.json()["detail"]
-    mock_fire.assert_not_called()
+    assert resp.status_code == 200
+    assert mock_fire.call_count == 1
 
 
 @pytest.mark.asyncio
+@patch(f"{_PROC}.verify_service_auth", new_callable=AsyncMock)
 @patch(f"{_PROC}.fire_analytics_event")
-async def test_send_interactions_missing_dataset_uri(mock_fire, config, pool):
+async def test_send_interactions_missing_dataset_uri(mock_fire, mock_auth, config, pool):
+    mock_auth.return_value = MagicMock(iss="did:plc:caller")
     app = _mock_app(config, pool)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -547,8 +561,10 @@ async def test_send_interactions_missing_dataset_uri(mock_fire, config, pool):
 
 
 @pytest.mark.asyncio
+@patch(f"{_PROC}.verify_service_auth", new_callable=AsyncMock)
 @patch(f"{_PROC}.fire_analytics_event")
-async def test_send_interactions_not_an_array(mock_fire, config, pool):
+async def test_send_interactions_not_an_array(mock_fire, mock_auth, config, pool):
+    mock_auth.return_value = MagicMock(iss="did:plc:caller")
     app = _mock_app(config, pool)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -563,8 +579,10 @@ async def test_send_interactions_not_an_array(mock_fire, config, pool):
 
 
 @pytest.mark.asyncio
+@patch(f"{_PROC}.verify_service_auth", new_callable=AsyncMock)
 @patch(f"{_PROC}.fire_analytics_event")
-async def test_send_interactions_all_three_types(mock_fire, config, pool):
+async def test_send_interactions_all_three_types(mock_fire, mock_auth, config, pool):
+    mock_auth.return_value = MagicMock(iss="did:plc:caller")
     app = _mock_app(config, pool)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -593,9 +611,11 @@ async def test_send_interactions_all_three_types(mock_fire, config, pool):
 
 
 @pytest.mark.asyncio
+@patch(f"{_PROC}.verify_service_auth", new_callable=AsyncMock)
 @patch(f"{_PROC}.fire_analytics_event")
-async def test_send_interactions_missing_key(mock_fire, config, pool):
+async def test_send_interactions_missing_key(mock_fire, mock_auth, config, pool):
     """Body without 'interactions' key should return 400."""
+    mock_auth.return_value = MagicMock(iss="did:plc:caller")
     app = _mock_app(config, pool)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -610,9 +630,11 @@ async def test_send_interactions_missing_key(mock_fire, config, pool):
 
 
 @pytest.mark.asyncio
+@patch(f"{_PROC}.verify_service_auth", new_callable=AsyncMock)
 @patch(f"{_PROC}.fire_analytics_event")
-async def test_send_interactions_non_dict_item(mock_fire, config, pool):
+async def test_send_interactions_non_dict_item(mock_fire, mock_auth, config, pool):
     """Non-object items in the interactions array should return 400."""
+    mock_auth.return_value = MagicMock(iss="did:plc:caller")
     app = _mock_app(config, pool)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -627,9 +649,11 @@ async def test_send_interactions_non_dict_item(mock_fire, config, pool):
 
 
 @pytest.mark.asyncio
+@patch(f"{_PROC}.verify_service_auth", new_callable=AsyncMock)
 @patch(f"{_PROC}.fire_analytics_event")
-async def test_send_interactions_boundary_at_max(mock_fire, config, pool):
+async def test_send_interactions_boundary_at_max(mock_fire, mock_auth, config, pool):
     """Exactly 100 interactions (the maximum) should succeed."""
+    mock_auth.return_value = MagicMock(iss="did:plc:caller")
     app = _mock_app(config, pool)
     transport = ASGITransport(app=app)
     interactions = [

--- a/tests/test_changestream.py
+++ b/tests/test_changestream.py
@@ -1,0 +1,440 @@
+"""Tests for the change stream event bus and WebSocket subscription endpoint."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+from atdata_app.changestream import ChangeEvent, ChangeStream, make_change_event
+from atdata_app.ingestion.processor import process_commit
+from atdata_app.xrpc.subscriptions import router as subscriptions_router
+
+
+# ---------------------------------------------------------------------------
+# ChangeStream unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestChangeStream:
+    def test_publish_assigns_monotonic_seq(self):
+        cs = ChangeStream()
+        ev1 = make_change_event(
+            event_type="create",
+            collection="science.alt.dataset.entry",
+            did="did:plc:test",
+            rkey="abc",
+        )
+        ev2 = make_change_event(
+            event_type="update",
+            collection="science.alt.dataset.entry",
+            did="did:plc:test",
+            rkey="def",
+        )
+        cs.publish(ev1)
+        cs.publish(ev2)
+        assert ev1.seq == 1
+        assert ev2.seq == 2
+        assert cs.current_seq == 2
+
+    def test_publish_delivers_to_subscribers(self):
+        cs = ChangeStream()
+        sub_id, queue = cs.subscribe()
+
+        ev = make_change_event(
+            event_type="create",
+            collection="science.alt.dataset.entry",
+            did="did:plc:test",
+            rkey="abc",
+        )
+        cs.publish(ev)
+
+        assert not queue.empty()
+        received = queue.get_nowait()
+        assert received.seq == 1
+        assert received.did == "did:plc:test"
+
+    def test_multiple_subscribers_receive_events(self):
+        cs = ChangeStream()
+        _, q1 = cs.subscribe()
+        _, q2 = cs.subscribe()
+
+        ev = make_change_event(
+            event_type="create",
+            collection="science.alt.dataset.entry",
+            did="did:plc:test",
+            rkey="abc",
+        )
+        cs.publish(ev)
+
+        assert not q1.empty()
+        assert not q2.empty()
+        assert q1.get_nowait().seq == 1
+        assert q2.get_nowait().seq == 1
+
+    def test_unsubscribe_removes_subscriber(self):
+        cs = ChangeStream()
+        sub_id, queue = cs.subscribe()
+        assert cs.subscriber_count == 1
+
+        cs.unsubscribe(sub_id)
+        assert cs.subscriber_count == 0
+
+        # Publishing after unsubscribe should not deliver
+        ev = make_change_event(
+            event_type="create",
+            collection="science.alt.dataset.entry",
+            did="did:plc:test",
+            rkey="abc",
+        )
+        cs.publish(ev)
+        assert queue.empty()
+
+    def test_full_queue_drops_event(self):
+        cs = ChangeStream(subscriber_queue_size=1)
+        _, queue = cs.subscribe()
+
+        ev1 = make_change_event(
+            event_type="create",
+            collection="science.alt.dataset.entry",
+            did="did:plc:test",
+            rkey="a",
+        )
+        ev2 = make_change_event(
+            event_type="create",
+            collection="science.alt.dataset.entry",
+            did="did:plc:test",
+            rkey="b",
+        )
+        cs.publish(ev1)
+        cs.publish(ev2)  # Should be dropped (queue full)
+
+        assert queue.qsize() == 1
+        assert queue.get_nowait().rkey == "a"
+
+    def test_replay_from_cursor(self):
+        cs = ChangeStream(buffer_size=10)
+        for i in range(5):
+            ev = make_change_event(
+                event_type="create",
+                collection="science.alt.dataset.entry",
+                did="did:plc:test",
+                rkey=str(i),
+            )
+            cs.publish(ev)
+
+        # Replay from seq 3 — should get events 4 and 5
+        replayed = cs.replay_from(3)
+        assert len(replayed) == 2
+        assert replayed[0].seq == 4
+        assert replayed[1].seq == 5
+
+    def test_replay_from_zero_returns_all(self):
+        cs = ChangeStream(buffer_size=10)
+        for i in range(3):
+            ev = make_change_event(
+                event_type="create",
+                collection="science.alt.dataset.entry",
+                did="did:plc:test",
+                rkey=str(i),
+            )
+            cs.publish(ev)
+
+        replayed = cs.replay_from(0)
+        assert len(replayed) == 3
+
+    def test_replay_cursor_too_old(self):
+        cs = ChangeStream(buffer_size=3)
+        for i in range(5):
+            ev = make_change_event(
+                event_type="create",
+                collection="science.alt.dataset.entry",
+                did="did:plc:test",
+                rkey=str(i),
+            )
+            cs.publish(ev)
+
+        # Buffer only holds seq 3, 4, 5 — cursor 1 is too old
+        replayed = cs.replay_from(1)
+        assert len(replayed) == 0
+
+    def test_replay_empty_buffer(self):
+        cs = ChangeStream()
+        assert cs.replay_from(0) == []
+
+    def test_bounded_buffer(self):
+        cs = ChangeStream(buffer_size=3)
+        for i in range(10):
+            ev = make_change_event(
+                event_type="create",
+                collection="science.alt.dataset.entry",
+                did="did:plc:test",
+                rkey=str(i),
+            )
+            cs.publish(ev)
+
+        assert len(cs._buffer) == 3
+        assert cs._buffer[0].seq == 8
+        assert cs._buffer[-1].seq == 10
+
+
+class TestChangeEvent:
+    def test_to_dict_create(self):
+        ev = ChangeEvent(
+            seq=1,
+            type="create",
+            collection="science.alt.dataset.entry",
+            did="did:plc:test",
+            rkey="abc",
+            timestamp="2026-01-01T00:00:00Z",
+            record={"name": "test"},
+            cid="bafytest",
+        )
+        d = ev.to_dict()
+        assert d["seq"] == 1
+        assert d["type"] == "create"
+        assert d["record"] == {"name": "test"}
+        assert d["cid"] == "bafytest"
+
+    def test_to_dict_delete_omits_record_and_cid(self):
+        ev = ChangeEvent(
+            seq=2,
+            type="delete",
+            collection="science.alt.dataset.entry",
+            did="did:plc:test",
+            rkey="abc",
+            timestamp="2026-01-01T00:00:00Z",
+        )
+        d = ev.to_dict()
+        assert "record" not in d
+        assert "cid" not in d
+
+
+class TestMakeChangeEvent:
+    def test_creates_event_with_timestamp(self):
+        ev = make_change_event(
+            event_type="create",
+            collection="science.alt.dataset.entry",
+            did="did:plc:test",
+            rkey="abc",
+            record={"name": "test"},
+            cid="bafytest",
+        )
+        assert ev.seq == 0  # Not yet assigned
+        assert ev.type == "create"
+        assert ev.timestamp  # Should have a timestamp
+
+
+# ---------------------------------------------------------------------------
+# Processor integration tests
+# ---------------------------------------------------------------------------
+
+_DB = "atdata_app.database"
+
+
+def _make_event(
+    did: str = "did:plc:test123",
+    collection: str = "science.alt.dataset.entry",
+    operation: str = "create",
+    rkey: str = "3xyz",
+    record: dict | None = None,
+    cid: str = "bafytest",
+) -> dict:
+    commit: dict = {
+        "rev": "rev1",
+        "operation": operation,
+        "collection": collection,
+        "rkey": rkey,
+    }
+    if operation != "delete":
+        commit["record"] = record or {
+            "$type": collection,
+            "name": "test-dataset",
+            "schemaRef": "at://did:plc:test/science.alt.dataset.schema/test@1.0.0",
+            "storage": {"$type": "science.alt.dataset.storageHttp", "shards": []},
+            "createdAt": "2025-01-01T00:00:00Z",
+        }
+        commit["cid"] = cid
+
+    return {
+        "did": did,
+        "time_us": 1725911162329308,
+        "kind": "commit",
+        "commit": commit,
+    }
+
+
+@pytest.mark.asyncio
+@patch(f"{_DB}.upsert_entry", new_callable=AsyncMock)
+async def test_processor_publishes_create_event(mock_upsert):
+    pool = AsyncMock()
+    cs = ChangeStream()
+    _, queue = cs.subscribe()
+
+    event = _make_event(operation="create")
+    await process_commit(pool, event, change_stream=cs)
+
+    assert not queue.empty()
+    change_event = queue.get_nowait()
+    assert change_event.type == "create"
+    assert change_event.collection == "science.alt.dataset.entry"
+    assert change_event.did == "did:plc:test123"
+    assert change_event.rkey == "3xyz"
+    assert change_event.record is not None
+    assert change_event.cid == "bafytest"
+
+
+@pytest.mark.asyncio
+@patch(f"{_DB}.delete_record", new_callable=AsyncMock)
+async def test_processor_publishes_delete_event(mock_delete):
+    pool = AsyncMock()
+    cs = ChangeStream()
+    _, queue = cs.subscribe()
+
+    event = _make_event(operation="delete")
+    await process_commit(pool, event, change_stream=cs)
+
+    assert not queue.empty()
+    change_event = queue.get_nowait()
+    assert change_event.type == "delete"
+    assert change_event.collection == "science.alt.dataset.entry"
+    assert change_event.record is None
+    assert change_event.cid is None
+
+
+@pytest.mark.asyncio
+@patch(f"{_DB}.upsert_entry", new_callable=AsyncMock)
+async def test_processor_no_event_on_upsert_failure(mock_upsert):
+    mock_upsert.side_effect = Exception("db error")
+    pool = AsyncMock()
+    cs = ChangeStream()
+    _, queue = cs.subscribe()
+
+    event = _make_event(operation="create")
+    await process_commit(pool, event, change_stream=cs)
+
+    assert queue.empty()
+
+
+@pytest.mark.asyncio
+@patch(f"{_DB}.upsert_entry", new_callable=AsyncMock)
+async def test_processor_works_without_change_stream(mock_upsert):
+    """Backward compat: process_commit works when change_stream is None."""
+    pool = AsyncMock()
+    event = _make_event(operation="create")
+    await process_commit(pool, event)
+    mock_upsert.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# WebSocket endpoint tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app_with_changestream():
+    """Minimal app with just the subscriptions router — no DB lifespan."""
+    app = FastAPI()
+    app.state.change_stream = ChangeStream()
+    app.include_router(subscriptions_router, prefix="/xrpc")
+    return app
+
+
+def test_websocket_subscribe_and_receive(app_with_changestream):
+    app = app_with_changestream
+    cs: ChangeStream = app.state.change_stream
+
+    with TestClient(app) as client:
+        with client.websocket_connect(
+            "/xrpc/science.alt.dataset.subscribeChanges"
+        ) as ws:
+            # Publish an event from another "thread"
+            cs.publish(
+                make_change_event(
+                    event_type="create",
+                    collection="science.alt.dataset.entry",
+                    did="did:plc:test",
+                    rkey="abc",
+                    record={"name": "test"},
+                    cid="bafytest",
+                )
+            )
+
+            data = ws.receive_json()
+            assert data["seq"] == 1
+            assert data["type"] == "create"
+            assert data["collection"] == "science.alt.dataset.entry"
+            assert data["did"] == "did:plc:test"
+            assert data["record"] == {"name": "test"}
+
+
+def test_websocket_cursor_replay(app_with_changestream):
+    app = app_with_changestream
+    cs: ChangeStream = app.state.change_stream
+
+    # Pre-populate buffer
+    for i in range(5):
+        cs.publish(
+            make_change_event(
+                event_type="create",
+                collection="science.alt.dataset.entry",
+                did="did:plc:test",
+                rkey=str(i),
+            )
+        )
+
+    with TestClient(app) as client:
+        with client.websocket_connect(
+            "/xrpc/science.alt.dataset.subscribeChanges?cursor=3"
+        ) as ws:
+            # Should replay events 4 and 5
+            msg1 = ws.receive_json()
+            assert msg1["seq"] == 4
+
+            msg2 = ws.receive_json()
+            assert msg2["seq"] == 5
+
+
+def test_websocket_disconnect_cleanup(app_with_changestream):
+    app = app_with_changestream
+    cs: ChangeStream = app.state.change_stream
+
+    with TestClient(app) as client:
+        with client.websocket_connect(
+            "/xrpc/science.alt.dataset.subscribeChanges"
+        ):
+            assert cs.subscriber_count == 1
+
+    # After disconnect, subscriber should be cleaned up
+    assert cs.subscriber_count == 0
+
+
+def test_websocket_multiple_subscribers(app_with_changestream):
+    app = app_with_changestream
+    cs: ChangeStream = app.state.change_stream
+
+    with TestClient(app) as client:
+        with client.websocket_connect(
+            "/xrpc/science.alt.dataset.subscribeChanges"
+        ) as ws1:
+            with client.websocket_connect(
+                "/xrpc/science.alt.dataset.subscribeChanges"
+            ) as ws2:
+                assert cs.subscriber_count == 2
+
+                cs.publish(
+                    make_change_event(
+                        event_type="create",
+                        collection="science.alt.dataset.entry",
+                        did="did:plc:test",
+                        rkey="abc",
+                    )
+                )
+
+                d1 = ws1.receive_json()
+                d2 = ws2.receive_json()
+                assert d1["seq"] == d2["seq"] == 1
+
+    assert cs.subscriber_count == 0

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -132,8 +132,7 @@ async def test_get_index_skeleton_not_found(mock_get_provider):
 
 
 @pytest.mark.asyncio
-@patch(f"{_QUERIES}.query_get_index_provider", new_callable=AsyncMock)
-async def test_get_index_skeleton_invalid_uri(mock_get_provider):
+async def test_get_index_skeleton_invalid_uri():
     app, pool = _make_app()
 
     transport = ASGITransport(app=app)

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,0 +1,541 @@
+"""Tests for index provider endpoints (skeleton/hydration pattern)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from atdata_app.config import AppConfig
+from atdata_app.ingestion.processor import process_commit
+from atdata_app.main import create_app
+
+_DB = "atdata_app.database"
+_QUERIES = "atdata_app.xrpc.queries"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_app() -> tuple:
+    config = AppConfig(dev_mode=True, hostname="localhost", port=8000)
+    app = create_app(config)
+    pool = AsyncMock()
+    app.state.db_pool = pool
+    return app, pool
+
+
+def _index_provider_row(
+    did: str = "did:plc:provider1",
+    rkey: str = "3abc",
+    endpoint_url: str = "https://example.com/skeleton",
+    name: str = "Genomics Index",
+    description: str = "Curated genomics datasets",
+) -> dict:
+    """Simulate an asyncpg Record as a dict-like object."""
+    return MagicMock(
+        **{
+            "__getitem__": lambda self, key: {
+                "did": did,
+                "rkey": rkey,
+                "cid": "bafyindex",
+                "name": name,
+                "description": description,
+                "endpoint_url": endpoint_url,
+                "created_at": "2025-01-01T00:00:00Z",
+                "indexed_at": "2025-01-01T00:00:00+00:00",
+            }[key],
+        }
+    )
+
+
+def _entry_row(did: str = "did:plc:author1", rkey: str = "3xyz") -> MagicMock:
+    return MagicMock(
+        **{
+            "__getitem__": lambda self, key: {
+                "did": did,
+                "rkey": rkey,
+                "cid": "bafyentry",
+                "name": "test-dataset",
+                "schema_ref": "at://did:plc:test/science.alt.dataset.schema/test@1.0.0",
+                "storage": '{"$type": "science.alt.dataset.storageHttp", "shards": []}',
+                "description": None,
+                "tags": None,
+                "license": None,
+                "size_samples": None,
+                "size_bytes": None,
+                "size_shards": None,
+                "created_at": "2025-01-01T00:00:00Z",
+                "indexed_at": "2025-01-01T00:00:00+00:00",
+            }[key],
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# getIndexSkeleton
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch(f"{_QUERIES}.query_get_index_provider", new_callable=AsyncMock)
+async def test_get_index_skeleton_success(mock_get_provider):
+    app, pool = _make_app()
+    mock_get_provider.return_value = _index_provider_row()
+
+    skeleton_response = {
+        "items": [{"uri": "at://did:plc:a/science.alt.dataset.entry/3xyz"}],
+        "cursor": "next123",
+    }
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = skeleton_response
+
+    with patch("atdata_app.xrpc.queries.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_resp
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get(
+                "/xrpc/science.alt.dataset.getIndexSkeleton",
+                params={"index": "at://did:plc:provider1/science.alt.dataset.index/3abc"},
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert len(data["items"]) == 1
+            assert data["items"][0]["uri"] == "at://did:plc:a/science.alt.dataset.entry/3xyz"
+            assert data["cursor"] == "next123"
+
+
+@pytest.mark.asyncio
+@patch(f"{_QUERIES}.query_get_index_provider", new_callable=AsyncMock)
+async def test_get_index_skeleton_not_found(mock_get_provider):
+    app, pool = _make_app()
+    mock_get_provider.return_value = None
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/xrpc/science.alt.dataset.getIndexSkeleton",
+            params={"index": "at://did:plc:missing/science.alt.dataset.index/3abc"},
+        )
+        assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+@patch(f"{_QUERIES}.query_get_index_provider", new_callable=AsyncMock)
+async def test_get_index_skeleton_invalid_uri(mock_get_provider):
+    app, pool = _make_app()
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/xrpc/science.alt.dataset.getIndexSkeleton",
+            params={"index": "not-a-uri"},
+        )
+        assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+@patch(f"{_QUERIES}.query_get_index_provider", new_callable=AsyncMock)
+async def test_get_index_skeleton_upstream_error(mock_get_provider):
+    app, pool = _make_app()
+    mock_get_provider.return_value = _index_provider_row()
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 500
+
+    with patch("atdata_app.xrpc.queries.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_resp
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get(
+                "/xrpc/science.alt.dataset.getIndexSkeleton",
+                params={"index": "at://did:plc:provider1/science.alt.dataset.index/3abc"},
+            )
+            assert resp.status_code == 502
+
+
+@pytest.mark.asyncio
+@patch(f"{_QUERIES}.query_get_index_provider", new_callable=AsyncMock)
+async def test_get_index_skeleton_upstream_unreachable(mock_get_provider):
+    app, pool = _make_app()
+    mock_get_provider.return_value = _index_provider_row()
+
+    with patch("atdata_app.xrpc.queries.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.get.side_effect = httpx.ConnectError("Connection refused")
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get(
+                "/xrpc/science.alt.dataset.getIndexSkeleton",
+                params={"index": "at://did:plc:provider1/science.alt.dataset.index/3abc"},
+            )
+            assert resp.status_code == 502
+
+
+@pytest.mark.asyncio
+@patch(f"{_QUERIES}.query_get_index_provider", new_callable=AsyncMock)
+async def test_get_index_skeleton_invalid_response(mock_get_provider):
+    """Upstream returns JSON without 'items' array."""
+    app, pool = _make_app()
+    mock_get_provider.return_value = _index_provider_row()
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"bad": "data"}
+
+    with patch("atdata_app.xrpc.queries.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_resp
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get(
+                "/xrpc/science.alt.dataset.getIndexSkeleton",
+                params={"index": "at://did:plc:provider1/science.alt.dataset.index/3abc"},
+            )
+            assert resp.status_code == 502
+
+
+# ---------------------------------------------------------------------------
+# getIndex (hydrated)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch(f"{_QUERIES}.query_get_entries", new_callable=AsyncMock)
+@patch(f"{_QUERIES}.query_get_index_provider", new_callable=AsyncMock)
+async def test_get_index_hydrated(mock_get_provider, mock_get_entries):
+    app, pool = _make_app()
+    mock_get_provider.return_value = _index_provider_row()
+    mock_get_entries.return_value = [_entry_row("did:plc:a", "3xyz")]
+
+    skeleton_response = {
+        "items": [
+            {"uri": "at://did:plc:a/science.alt.dataset.entry/3xyz"},
+        ],
+        "cursor": "next456",
+    }
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = skeleton_response
+
+    with patch("atdata_app.xrpc.queries.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_resp
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get(
+                "/xrpc/science.alt.dataset.getIndex",
+                params={"index": "at://did:plc:provider1/science.alt.dataset.index/3abc"},
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert len(data["items"]) == 1
+            assert data["items"][0]["name"] == "test-dataset"
+            assert data["cursor"] == "next456"
+
+
+@pytest.mark.asyncio
+@patch(f"{_QUERIES}.query_get_entries", new_callable=AsyncMock)
+@patch(f"{_QUERIES}.query_get_index_provider", new_callable=AsyncMock)
+async def test_get_index_omits_missing_entries(mock_get_provider, mock_get_entries):
+    """Entries not in the DB should be silently omitted."""
+    app, pool = _make_app()
+    mock_get_provider.return_value = _index_provider_row()
+    # Return only one of two requested entries
+    mock_get_entries.return_value = [_entry_row("did:plc:a", "3xyz")]
+
+    skeleton_response = {
+        "items": [
+            {"uri": "at://did:plc:a/science.alt.dataset.entry/3xyz"},
+            {"uri": "at://did:plc:b/science.alt.dataset.entry/3deleted"},
+        ],
+    }
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = skeleton_response
+
+    with patch("atdata_app.xrpc.queries.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_resp
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get(
+                "/xrpc/science.alt.dataset.getIndex",
+                params={"index": "at://did:plc:provider1/science.alt.dataset.index/3abc"},
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert len(data["items"]) == 1
+
+
+@pytest.mark.asyncio
+@patch(f"{_QUERIES}.query_get_index_provider", new_callable=AsyncMock)
+async def test_get_index_not_found(mock_get_provider):
+    app, pool = _make_app()
+    mock_get_provider.return_value = None
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/xrpc/science.alt.dataset.getIndex",
+            params={"index": "at://did:plc:missing/science.alt.dataset.index/3abc"},
+        )
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# listIndexes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch(f"{_QUERIES}.query_list_index_providers", new_callable=AsyncMock)
+async def test_list_indexes(mock_list):
+    app, pool = _make_app()
+    mock_list.return_value = [_index_provider_row()]
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/xrpc/science.alt.dataset.listIndexes")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["indexes"]) == 1
+        assert data["indexes"][0]["name"] == "Genomics Index"
+        assert data["indexes"][0]["endpointUrl"] == "https://example.com/skeleton"
+
+
+@pytest.mark.asyncio
+@patch(f"{_QUERIES}.query_list_index_providers", new_callable=AsyncMock)
+async def test_list_indexes_empty(mock_list):
+    app, pool = _make_app()
+    mock_list.return_value = []
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/xrpc/science.alt.dataset.listIndexes")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["indexes"] == []
+        assert data["cursor"] is None
+
+
+@pytest.mark.asyncio
+@patch(f"{_QUERIES}.query_list_index_providers", new_callable=AsyncMock)
+async def test_list_indexes_with_repo_filter(mock_list):
+    app, pool = _make_app()
+    mock_list.return_value = []
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/xrpc/science.alt.dataset.listIndexes",
+            params={"repo": "did:plc:provider1"},
+        )
+        assert resp.status_code == 200
+        mock_list.assert_called_once_with(pool, "did:plc:provider1", 50, None, None, None)
+
+
+# ---------------------------------------------------------------------------
+# publishIndex
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("atdata_app.xrpc.procedures.verify_service_auth", new_callable=AsyncMock)
+@patch("atdata_app.xrpc.procedures._resolve_pds", new_callable=AsyncMock)
+@patch("atdata_app.xrpc.procedures._proxy_create_record", new_callable=AsyncMock)
+async def test_publish_index(mock_proxy, mock_pds, mock_auth):
+    app, pool = _make_app()
+
+    mock_auth.return_value = MagicMock(iss="did:plc:publisher1")
+    mock_pds.return_value = "https://pds.example.com"
+    mock_proxy.return_value = {
+        "uri": "at://did:plc:publisher1/science.alt.dataset.index/3abc",
+        "cid": "bafynew",
+    }
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/xrpc/science.alt.dataset.publishIndex",
+            json={
+                "record": {
+                    "name": "Genomics Index",
+                    "endpointUrl": "https://example.com/skeleton",
+                    "createdAt": "2025-01-01T00:00:00Z",
+                },
+            },
+            headers={
+                "Authorization": "Bearer test-token",
+                "X-PDS-Auth": "pds-token",
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["uri"] == "at://did:plc:publisher1/science.alt.dataset.index/3abc"
+        assert data["cid"] == "bafynew"
+
+
+@pytest.mark.asyncio
+@patch("atdata_app.xrpc.procedures.verify_service_auth", new_callable=AsyncMock)
+async def test_publish_index_missing_field(mock_auth):
+    app, pool = _make_app()
+    mock_auth.return_value = MagicMock(iss="did:plc:publisher1")
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/xrpc/science.alt.dataset.publishIndex",
+            json={
+                "record": {
+                    "name": "Test",
+                    "createdAt": "2025-01-01T00:00:00Z",
+                    # missing endpointUrl
+                },
+            },
+            headers={
+                "Authorization": "Bearer test-token",
+                "X-PDS-Auth": "pds-token",
+            },
+        )
+        assert resp.status_code == 400
+        assert "endpointUrl" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+@patch("atdata_app.xrpc.procedures.verify_service_auth", new_callable=AsyncMock)
+async def test_publish_index_http_url_rejected(mock_auth):
+    app, pool = _make_app()
+    mock_auth.return_value = MagicMock(iss="did:plc:publisher1")
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/xrpc/science.alt.dataset.publishIndex",
+            json={
+                "record": {
+                    "name": "Bad Index",
+                    "endpointUrl": "http://insecure.example.com/skeleton",
+                    "createdAt": "2025-01-01T00:00:00Z",
+                },
+            },
+            headers={
+                "Authorization": "Bearer test-token",
+                "X-PDS-Auth": "pds-token",
+            },
+        )
+        assert resp.status_code == 400
+        assert "HTTPS" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+@patch("atdata_app.xrpc.procedures.verify_service_auth", new_callable=AsyncMock)
+async def test_publish_index_invalid_type(mock_auth):
+    app, pool = _make_app()
+    mock_auth.return_value = MagicMock(iss="did:plc:publisher1")
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/xrpc/science.alt.dataset.publishIndex",
+            json={
+                "record": {
+                    "$type": "science.alt.dataset.entry",
+                    "name": "Wrong Type",
+                    "endpointUrl": "https://example.com/skeleton",
+                    "createdAt": "2025-01-01T00:00:00Z",
+                },
+            },
+            headers={
+                "Authorization": "Bearer test-token",
+                "X-PDS-Auth": "pds-token",
+            },
+        )
+        assert resp.status_code == 400
+        assert "Invalid $type" in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Ingestion: index provider records
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch(f"{_DB}.upsert_index_provider", new_callable=AsyncMock)
+async def test_process_commit_index_provider(mock_upsert):
+    pool = AsyncMock()
+    event = {
+        "did": "did:plc:provider1",
+        "time_us": 1725911162329308,
+        "kind": "commit",
+        "commit": {
+            "rev": "rev1",
+            "operation": "create",
+            "collection": "science.alt.dataset.index",
+            "rkey": "3abc",
+            "record": {
+                "$type": "science.alt.dataset.index",
+                "name": "Genomics Index",
+                "endpointUrl": "https://example.com/skeleton",
+                "createdAt": "2025-01-01T00:00:00Z",
+            },
+            "cid": "bafyindex",
+        },
+    }
+    await process_commit(pool, event)
+    mock_upsert.assert_called_once_with(
+        pool, "did:plc:provider1", "3abc", "bafyindex", event["commit"]["record"]
+    )
+
+
+@pytest.mark.asyncio
+@patch(f"{_DB}.delete_record", new_callable=AsyncMock)
+async def test_process_commit_delete_index_provider(mock_delete):
+    pool = AsyncMock()
+    event = {
+        "did": "did:plc:provider1",
+        "time_us": 1725911162329308,
+        "kind": "commit",
+        "commit": {
+            "rev": "rev1",
+            "operation": "delete",
+            "collection": "science.alt.dataset.index",
+            "rkey": "3abc",
+        },
+    }
+    await process_commit(pool, event)
+    mock_delete.assert_called_once_with(pool, "index_providers", "did:plc:provider1", "3abc")

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -143,6 +143,26 @@ async def test_process_commit_lens():
 
 
 @pytest.mark.asyncio
+async def test_process_commit_index_provider():
+    patcher, mock_upsert = _patch_upsert("index_providers")
+    with patcher:
+        pool = AsyncMock()
+        event = _make_event(
+            collection="science.alt.dataset.index",
+            record={
+                "$type": "science.alt.dataset.index",
+                "name": "Genomics Index",
+                "endpointUrl": "https://example.com/skeleton",
+                "createdAt": "2025-01-01T00:00:00Z",
+            },
+        )
+        await process_commit(pool, event)
+        mock_upsert.assert_called_once_with(
+            pool, "did:plc:test123", "3xyz", "bafytest", event["commit"]["record"]
+        )
+
+
+@pytest.mark.asyncio
 async def test_process_commit_update():
     """Update operations should route to the same upsert function as create."""
     patcher, mock_upsert = _patch_upsert("entries")

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -8,7 +8,6 @@ import pytest
 
 from atdata_app.ingestion.processor import process_commit
 
-# All patches target the `db` module reference used inside processor.py
 _DB = "atdata_app.database"
 
 
@@ -44,15 +43,22 @@ def _make_event(
     }
 
 
+def _patch_upsert(table: str):
+    """Patch a single entry in UPSERT_FNS by table name."""
+    mock = AsyncMock()
+    return patch.dict(f"{_DB}.UPSERT_FNS", {table: mock}), mock
+
+
 @pytest.mark.asyncio
-@patch(f"{_DB}.upsert_entry", new_callable=AsyncMock)
-async def test_process_commit_create(mock_upsert):
-    pool = AsyncMock()
-    event = _make_event(operation="create")
-    await process_commit(pool, event)
-    mock_upsert.assert_called_once_with(
-        pool, "did:plc:test123", "3xyz", "bafytest", event["commit"]["record"]
-    )
+async def test_process_commit_create():
+    patcher, mock_upsert = _patch_upsert("entries")
+    with patcher:
+        pool = AsyncMock()
+        event = _make_event(operation="create")
+        await process_commit(pool, event)
+        mock_upsert.assert_called_once_with(
+            pool, "did:plc:test123", "3xyz", "bafytest", event["commit"]["record"]
+        )
 
 
 @pytest.mark.asyncio
@@ -72,85 +78,89 @@ async def test_process_commit_delete(mock_delete):
 
 
 @pytest.mark.asyncio
-@patch(f"{_DB}.upsert_schema", new_callable=AsyncMock)
-async def test_process_commit_schema(mock_upsert):
-    pool = AsyncMock()
-    event = _make_event(
-        collection="science.alt.dataset.schema",
-        record={
-            "$type": "science.alt.dataset.schema",
-            "name": "TestSchema",
-            "version": "1.0.0",
-            "schemaType": "jsonSchema",
-            "schema": {"$type": "science.alt.dataset.schema#jsonSchemaFormat"},
-            "createdAt": "2025-01-01T00:00:00Z",
-        },
-    )
-    await process_commit(pool, event)
-    mock_upsert.assert_called_once_with(
-        pool, "did:plc:test123", "3xyz", "bafytest", event["commit"]["record"]
-    )
+async def test_process_commit_schema():
+    patcher, mock_upsert = _patch_upsert("schemas")
+    with patcher:
+        pool = AsyncMock()
+        event = _make_event(
+            collection="science.alt.dataset.schema",
+            record={
+                "$type": "science.alt.dataset.schema",
+                "name": "TestSchema",
+                "version": "1.0.0",
+                "schemaType": "jsonSchema",
+                "schema": {"$type": "science.alt.dataset.schema#jsonSchemaFormat"},
+                "createdAt": "2025-01-01T00:00:00Z",
+            },
+        )
+        await process_commit(pool, event)
+        mock_upsert.assert_called_once_with(
+            pool, "did:plc:test123", "3xyz", "bafytest", event["commit"]["record"]
+        )
 
 
 @pytest.mark.asyncio
-@patch(f"{_DB}.upsert_label", new_callable=AsyncMock)
-async def test_process_commit_label(mock_upsert):
-    pool = AsyncMock()
-    event = _make_event(
-        collection="science.alt.dataset.label",
-        record={
-            "$type": "science.alt.dataset.label",
-            "name": "mnist",
-            "datasetUri": "at://did:plc:test/science.alt.dataset.entry/3xyz",
-            "createdAt": "2025-01-01T00:00:00Z",
-        },
-    )
-    await process_commit(pool, event)
-    mock_upsert.assert_called_once_with(
-        pool, "did:plc:test123", "3xyz", "bafytest", event["commit"]["record"]
-    )
+async def test_process_commit_label():
+    patcher, mock_upsert = _patch_upsert("labels")
+    with patcher:
+        pool = AsyncMock()
+        event = _make_event(
+            collection="science.alt.dataset.label",
+            record={
+                "$type": "science.alt.dataset.label",
+                "name": "mnist",
+                "datasetUri": "at://did:plc:test/science.alt.dataset.entry/3xyz",
+                "createdAt": "2025-01-01T00:00:00Z",
+            },
+        )
+        await process_commit(pool, event)
+        mock_upsert.assert_called_once_with(
+            pool, "did:plc:test123", "3xyz", "bafytest", event["commit"]["record"]
+        )
 
 
 @pytest.mark.asyncio
-@patch(f"{_DB}.upsert_lens", new_callable=AsyncMock)
-async def test_process_commit_lens(mock_upsert):
-    pool = AsyncMock()
-    event = _make_event(
-        collection="science.alt.dataset.lens",
-        record={
-            "$type": "science.alt.dataset.lens",
-            "name": "test-lens",
-            "sourceSchema": "at://did:plc:test/science.alt.dataset.schema/a@1.0.0",
-            "targetSchema": "at://did:plc:test/science.alt.dataset.schema/b@1.0.0",
-            "getterCode": {"repository": "https://github.com/test/repo", "commit": "abc", "path": "get.py"},
-            "putterCode": {"repository": "https://github.com/test/repo", "commit": "abc", "path": "put.py"},
-            "createdAt": "2025-01-01T00:00:00Z",
-        },
-    )
-    await process_commit(pool, event)
-    mock_upsert.assert_called_once_with(
-        pool, "did:plc:test123", "3xyz", "bafytest", event["commit"]["record"]
-    )
+async def test_process_commit_lens():
+    patcher, mock_upsert = _patch_upsert("lenses")
+    with patcher:
+        pool = AsyncMock()
+        event = _make_event(
+            collection="science.alt.dataset.lens",
+            record={
+                "$type": "science.alt.dataset.lens",
+                "name": "test-lens",
+                "sourceSchema": "at://did:plc:test/science.alt.dataset.schema/a@1.0.0",
+                "targetSchema": "at://did:plc:test/science.alt.dataset.schema/b@1.0.0",
+                "getterCode": {"repository": "https://github.com/test/repo", "commit": "abc", "path": "get.py"},
+                "putterCode": {"repository": "https://github.com/test/repo", "commit": "abc", "path": "put.py"},
+                "createdAt": "2025-01-01T00:00:00Z",
+            },
+        )
+        await process_commit(pool, event)
+        mock_upsert.assert_called_once_with(
+            pool, "did:plc:test123", "3xyz", "bafytest", event["commit"]["record"]
+        )
 
 
 @pytest.mark.asyncio
-@patch(f"{_DB}.upsert_entry", new_callable=AsyncMock)
-async def test_process_commit_update(mock_upsert):
+async def test_process_commit_update():
     """Update operations should route to the same upsert function as create."""
-    pool = AsyncMock()
-    event = _make_event(operation="update")
-    await process_commit(pool, event)
-    mock_upsert.assert_called_once_with(
-        pool, "did:plc:test123", "3xyz", "bafytest", event["commit"]["record"]
-    )
+    patcher, mock_upsert = _patch_upsert("entries")
+    with patcher:
+        pool = AsyncMock()
+        event = _make_event(operation="update")
+        await process_commit(pool, event)
+        mock_upsert.assert_called_once_with(
+            pool, "did:plc:test123", "3xyz", "bafytest", event["commit"]["record"]
+        )
 
 
 @pytest.mark.asyncio
-@patch(f"{_DB}.upsert_entry", new_callable=AsyncMock)
-async def test_process_commit_upsert_error_is_caught(mock_upsert):
+async def test_process_commit_upsert_error_is_caught():
     """Upsert failures should be logged, not raised."""
-    mock_upsert.side_effect = Exception("db error")
-    pool = AsyncMock()
-    event = _make_event(operation="create")
-    # Should not raise
-    await process_commit(pool, event)
+    mock = AsyncMock(side_effect=Exception("db error"))
+    with patch.dict(f"{_DB}.UPSERT_FNS", {"entries": mock}):
+        pool = AsyncMock()
+        event = _make_event(operation="create")
+        # Should not raise
+        await process_commit(pool, event)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -162,6 +162,7 @@ class TestSchemaValidation:
             "entries",
             "labels",
             "lenses",
+            "index_providers",
             "cursor_state",
             "analytics_events",
             "analytics_counters",
@@ -196,6 +197,8 @@ class TestSchemaValidation:
             "idx_lenses_did",
             "idx_analytics_events_type_created",
             "idx_analytics_events_target",
+            "idx_index_providers_did",
+            "idx_index_providers_indexed_at",
         }
         async with db_pool.acquire() as conn:
             rows = await conn.fetch(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,6 +10,7 @@ from atdata_app.models import (
     make_at_uri,
     parse_at_uri,
     row_to_entry,
+    row_to_index_provider,
     row_to_label,
     row_to_lens,
     row_to_schema,
@@ -193,6 +194,7 @@ _LABEL_ROW = {
 def test_row_to_label():
     d = row_to_label(_LABEL_ROW)
     assert d["uri"] == "at://did:plc:abc/science.alt.dataset.label/3lbl"
+    assert d["did"] == "did:plc:abc"
     assert d["datasetUri"] == _LABEL_ROW["dataset_uri"]
     assert d["version"] == "1.0.0"
     assert d["description"] == "First version"
@@ -227,6 +229,7 @@ _LENS_ROW = {
 def test_row_to_lens():
     d = row_to_lens(_LENS_ROW)
     assert d["uri"] == "at://did:plc:abc/science.alt.dataset.lens/3lens"
+    assert d["did"] == "did:plc:abc"
     assert d["sourceSchema"] == _LENS_ROW["source_schema"]
     assert d["getterCode"] == _LENS_ROW["getter_code"]
     assert d["description"] == "Transforms A to B"
@@ -249,3 +252,33 @@ def test_row_to_lens_json_string_code():
     d = row_to_lens(row)
     assert d["getterCode"] == {"repo": "x"}
     assert d["putterCode"] == {"repo": "y"}
+
+
+# ---------------------------------------------------------------------------
+# row_to_index_provider
+# ---------------------------------------------------------------------------
+
+_INDEX_PROVIDER_ROW = {
+    "did": "did:plc:provider1",
+    "rkey": "3idx",
+    "cid": "bafyindex",
+    "name": "Genomics Index",
+    "description": "Curated genomics datasets",
+    "endpoint_url": "https://example.com/skeleton",
+    "created_at": "2025-01-01T00:00:00Z",
+}
+
+
+def test_row_to_index_provider():
+    d = row_to_index_provider(_INDEX_PROVIDER_ROW)
+    assert d["uri"] == "at://did:plc:provider1/science.alt.dataset.index/3idx"
+    assert d["did"] == "did:plc:provider1"
+    assert d["name"] == "Genomics Index"
+    assert d["endpointUrl"] == "https://example.com/skeleton"
+    assert d["description"] == "Curated genomics datasets"
+
+
+def test_row_to_index_provider_omits_null_description():
+    row = {**_INDEX_PROVIDER_ROW, "description": None}
+    d = row_to_index_provider(row)
+    assert "description" not in d

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -193,6 +193,7 @@ _LABEL_ROW = {
 def test_row_to_label():
     d = row_to_label(_LABEL_ROW)
     assert d["uri"] == "at://did:plc:abc/science.alt.dataset.label/3lbl"
+    assert d["did"] == "did:plc:abc"
     assert d["datasetUri"] == _LABEL_ROW["dataset_uri"]
     assert d["version"] == "1.0.0"
     assert d["description"] == "First version"
@@ -227,6 +228,7 @@ _LENS_ROW = {
 def test_row_to_lens():
     d = row_to_lens(_LENS_ROW)
     assert d["uri"] == "at://did:plc:abc/science.alt.dataset.lens/3lens"
+    assert d["did"] == "did:plc:abc"
     assert d["sourceSchema"] == _LENS_ROW["source_schema"]
     assert d["getterCode"] == _LENS_ROW["getter_code"]
     assert d["description"] == "Transforms A to B"

--- a/uv.lock
+++ b/uv.lock
@@ -75,7 +75,7 @@ wheels = [
 
 [[package]]
 name = "atdata-app"
-version = "0.3.0b1"
+version = "0.4.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
## Summary

- `sendInteractions` XRPC procedure for anonymous usage telemetry (download, citation, derivative events) (#21)
- Skeleton/hydration pattern for third-party dataset indexes — `getIndexSkeleton`, `getIndex`, `listIndexes`, `publishIndex` (#20)
- `subscribeChanges` WebSocket endpoint for real-time change streaming with cursor replay (#22)
- Array format type recognition and ndarray v1.1.0 annotation display in frontend (#30)
- `atdata-lexicon` git submodule at `lexicons/` pinned to v0.2.1b1 (#27)
- Ingestion processor refactored to `UPSERT_FNS` dispatch dict

## Test plan

- [x] 214 tests passing (unit + integration)
- [x] Lint clean (ruff)
- [x] Version bumped to 0.4.0b1
- [x] Lockfile updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)